### PR TITLE
chore: remove command block from init-generated config

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -582,46 +582,6 @@ export function registerCodeCommands(program: Command): void {
                 'Voice: Scandinavian calm—precise, concise, confident. You are Berget Code Quality agent. Specialist in code quality assurance, testing, building, and pull request management.\n\nCore responsibilities:\n  - Run comprehensive test suites (npm test, npm run test, jest, vitest)\n  - Execute build processes (npm run build, webpack, vite, tsc)\n  - Create and manage pull requests with proper descriptions\n  - Monitor GitHub for Copilot/reviewer comments\n  - Ensure code quality standards are met\n  - Validate linting and formatting (npm run lint, prettier)\n  - Check test coverage and performance benchmarks\n  - Handle CI/CD pipeline validation\n\nCommon CLI commands:\n  - npm test or npm run test (run test suite)\n  - npm run build (build project)\n  - npm run lint (run linting)\n  - npm run format (format code)\n  - npm run test:coverage (check coverage)\n  - gh pr create (create pull request)\n  - gh pr view --comments (check PR comments)\n  - git add . && git commit -m "message" && git push (commit and push)\n\nPR Workflow:\n  1. Ensure all tests pass: npm test\n  2. Build successfully: npm run build\n  3. Create/update PR with clear description\n  4. Monitor for reviewer comments\n  5. Address feedback promptly\n  6. Update PR with fixes\n  7. Ensure CI checks pass\n\nAlways provide specific command examples and wait for processes to complete before proceeding.',
             },
           },
-          command: {
-            fullstack: {
-              description: 'Switch to Fullstack (router)',
-              template: '{{input}}',
-              agent: 'fullstack',
-            },
-            route: {
-              description:
-                'Let Fullstack auto-route to the right persona based on files/intent',
-              template: 'ROUTE {{input}}',
-              agent: 'fullstack',
-              subtask: true,
-            },
-            frontend: {
-              description: 'Switch to Frontend persona',
-              template: '{{input}}',
-              agent: 'frontend',
-            },
-            backend: {
-              description: 'Switch to Backend persona',
-              template: '{{input}}',
-              agent: 'backend',
-            },
-            devops: {
-              description: 'Switch to DevOps persona',
-              template: '{{input}}',
-              agent: 'devops',
-            },
-            app: {
-              description: 'Switch to App persona',
-              template: '{{input}}',
-              agent: 'app',
-            },
-            quality: {
-              description:
-                'Switch to Quality agent for testing, building, and PR management',
-              template: '{{input}}',
-              agent: 'quality',
-            },
-          },
           watcher: {
             ignore: ['node_modules', 'dist', '.git', 'coverage'],
           },


### PR DESCRIPTION
## Summary
- Remove the `command` block from the config object generated by `berget code init` in `src/commands/code.ts`
- The block generated 7 agent-switching commands (`/fullstack`, `/route`, `/frontend`, `/backend`, `/devops`, `/app`, `/quality`) in the output `opencode.json`
- These are unnecessary since OpenCode supports native agent switching via the tab key