### PR TITLE
Remove username, share, and autoupdate from generated opencode.json config

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -503,9 +503,6 @@ export function registerCodeCommands(program: Command): void {
         const config = {
           $schema: 'https://opencode.ai/config.json',
           plugin: ['@bergetai/opencode-auth@1.0.16'],
-          username: 'berget-code',
-          share: 'manual',
-          autoupdate: true,
           agent: {
             fullstack: {
               temperature: 0.3,
@@ -843,9 +840,6 @@ export function registerCodeCommands(program: Command): void {
         const latestConfig = {
           $schema: 'https://opencode.ai/config.json',
           plugin: ['@bergetai/opencode-auth@1.0.16'],
-          username: 'berget-code',
-          share: 'manual',
-          autoupdate: true,
           agent: {
             fullstack: {
               temperature: 0.3,


### PR DESCRIPTION
## Summary
- Remove `username`, `share`, and `autoupdate` fields from both `code init` and `code update` generated configs
- These fields are not needed in the generated opencode.json — the plugin handles auth and model discovery