### PR TITLE
Remove watcher from generated opencode.json config

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -581,9 +581,6 @@ export function registerCodeCommands(program: Command): void {
                 'Voice: Scandinavian calm—precise, concise, confident. You are Berget Code Quality agent. Specialist in code quality assurance, testing, building, and pull request management.\n\nCore responsibilities:\n  - Run comprehensive test suites (npm test, npm run test, jest, vitest)\n  - Execute build processes (npm run build, webpack, vite, tsc)\n  - Create and manage pull requests with proper descriptions\n  - Monitor GitHub for Copilot/reviewer comments\n  - Ensure code quality standards are met\n  - Validate linting and formatting (npm run lint, prettier)\n  - Check test coverage and performance benchmarks\n  - Handle CI/CD pipeline validation\n\nCommon CLI commands:\n  - npm test or npm run test (run test suite)\n  - npm run build (build project)\n  - npm run lint (run linting)\n  - npm run format (format code)\n  - npm run test:coverage (check coverage)\n  - gh pr create (create pull request)\n  - gh pr view --comments (check PR comments)\n  - git add . && git commit -m "message" && git push (commit and push)\n\nPR Workflow:\n  1. Ensure all tests pass: npm test\n  2. Build successfully: npm run build\n  3. Create/update PR with clear description\n  4. Monitor for reviewer comments\n  5. Address feedback promptly\n  6. Update PR with fixes\n  7. Ensure CI checks pass\n\nAlways provide specific command examples and wait for processes to complete before proceeding.',
             },
           },
-          watcher: {
-            ignore: ['node_modules', 'dist', '.git', 'coverage'],
-          },
         }
 
         // Ask for permission to create config files
@@ -966,9 +963,6 @@ export function registerCodeCommands(program: Command): void {
               template: '{{input}}',
               agent: 'quality',
             },
-          },
-          watcher: {
-            ignore: ['node_modules', 'dist', '.git', 'coverage'],
           },
         }
 


### PR DESCRIPTION
## Summary
- Remove the `watcher` section from both `code init` and `code update` generated configs
- These defaults are already handled by opencode itself