### PR TITLE
chore: remove pinned version from opencode-auth plugin

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -65,7 +65,7 @@ export function registerCodeCommands(program: Command): void {
 
         const config = {
           $schema: 'https://opencode.ai/config.json',
-          plugin: ['@bergetai/opencode-auth@1.0.16'],
+          plugin: ['@bergetai/opencode-auth'],
         };
 
         const agentsDir = path.join(process.cwd(), '.opencode', 'agents');


### PR DESCRIPTION
## Summary

Remove pinned version from `@bergetai/opencode-auth` plugin reference in `berget code init` command.

### Changes

- `src/commands/code.ts`: `@bergetai/opencode-auth@1.0.16` → `@bergetai/opencode-auth`

### Why

The `setup` flow already uses unpinned version. Aligning `init` command to match ensures users always get the latest plugin version with latest features and fixes (including Kimi K2.6 vision support from v1.0.21).