### PR TITLE
chore: pin opencode-auth plugin to v1.0.21

### DIFF
--- a/src/commands/code/__tests__/setup-flow.test.ts
+++ b/src/commands/code/__tests__/setup-flow.test.ts
@@ -67,7 +67,7 @@ describe('runInit', () => {
       const written = files.getWrittenFiles();
       expect(written.has('/home/user/project/opencode.json')).toBe(true);
       const config = JSON.parse(written.get('/home/user/project/opencode.json')!);
-      expect(config.plugin).toContain('@bergetai/opencode-auth');
+      expect(config.plugin).toContain('@bergetai/opencode-auth@1.0.21');
     });
 
     it('sets up opencode globally without existing config', async () => {
@@ -221,7 +221,7 @@ describe('runInit', () => {
       const config = JSON.parse(written.get('/home/user/project/opencode.json')!);
       expect(config.customField).toBe('should-preserve');
       expect(config.plugin).toContain('other-plugin');
-      expect(config.plugin).toContain('@bergetai/opencode-auth');
+      expect(config.plugin).toContain('@bergetai/opencode-auth@1.0.21');
     });
 
     it('preserves jsonc comments when updating', async () => {
@@ -267,7 +267,7 @@ describe('runInit', () => {
         JSON.stringify(
           {
             $schema: 'https://opencode.ai/config.json',
-            plugin: ['@bergetai/opencode-auth'],
+            plugin: ['@bergetai/opencode-auth@1.0.21'],
           },
           null,
           2,
@@ -280,7 +280,7 @@ describe('runInit', () => {
       const written = files.getWrittenFiles();
       const content = written.get('/home/user/project/opencode.json')!;
       const config = JSON.parse(content);
-      expect(config.plugin).toEqual(['@bergetai/opencode-auth']);
+      expect(config.plugin).toEqual(['@bergetai/opencode-auth@1.0.21']);
       expect(content).toContain('$schema');
     });
 

--- a/src/commands/code/init.ts
+++ b/src/commands/code/init.ts
@@ -16,7 +16,7 @@ import { SpawnCommandRunner } from './adapters/spawn-command-runner.js';
 import { configureAuth } from './auth-sync.js';
 import { CancelledError, CommandFailedError, PrerequisiteError } from './errors';
 
-const OPENCODE_PLUGIN = '@bergetai/opencode-auth';
+const OPENCODE_PLUGIN = '@bergetai/opencode-auth@1.0.21';
 const PI_PROVIDER = 'npm:@bergetai/pi-provider';
 const OPENCODE_PLUGIN_NAME = '@bergetai/opencode-auth';
 const PI_PROVIDER_NAME = '@bergetai/pi-provider';


### PR DESCRIPTION
## Summary

Pin `@bergetai/opencode-auth` to version `1.0.21` to ensure users always get the exact version with latest features and fixes.

### Changes

- `src/commands/code/init.ts`: `@bergetai/opencode-auth` → `@bergetai/opencode-auth@1.0.21`
- `src/commands/code/__tests__/setup-flow.test.ts`: Update test expectations to match pinned version

### Why

Without a pinned version, npm/OpenCode caching can cause users to get stuck on older plugin versions (e.g., `1.0.15` or `1.0.16`) even when newer versions are available.

Version `1.0.21` includes the vision support fix for `moonshotai/Kimi-K2.6` model (see [opencode-berget-auth#17](https://github.com/berget-ai/opencode-berget-auth/pull/17)).