### PR TITLE
chore: bump opencode-auth plugin to v1.0.22

### DIFF
--- a/src/commands/code/__tests__/setup-flow.test.ts
+++ b/src/commands/code/__tests__/setup-flow.test.ts
@@ -67,7 +67,7 @@ describe('runInit', () => {
       const written = files.getWrittenFiles();
       expect(written.has('/home/user/project/opencode.json')).toBe(true);
       const config = JSON.parse(written.get('/home/user/project/opencode.json')!);
-      expect(config.plugin).toContain('@bergetai/opencode-auth@1.0.21');
+      expect(config.plugin).toContain('@bergetai/opencode-auth@1.0.22');
     });
 
     it('sets up opencode globally without existing config', async () => {
@@ -221,7 +221,7 @@ describe('runInit', () => {
       const config = JSON.parse(written.get('/home/user/project/opencode.json')!);
       expect(config.customField).toBe('should-preserve');
       expect(config.plugin).toContain('other-plugin');
-      expect(config.plugin).toContain('@bergetai/opencode-auth@1.0.21');
+      expect(config.plugin).toContain('@bergetai/opencode-auth@1.0.22');
     });
 
     it('preserves jsonc comments when updating', async () => {
@@ -267,7 +267,7 @@ describe('runInit', () => {
         JSON.stringify(
           {
             $schema: 'https://opencode.ai/config.json',
-            plugin: ['@bergetai/opencode-auth@1.0.21'],
+            plugin: ['@bergetai/opencode-auth@1.0.22'],
           },
           null,
           2,
@@ -280,7 +280,7 @@ describe('runInit', () => {
       const written = files.getWrittenFiles();
       const content = written.get('/home/user/project/opencode.json')!;
       const config = JSON.parse(content);
-      expect(config.plugin).toEqual(['@bergetai/opencode-auth@1.0.21']);
+      expect(config.plugin).toEqual(['@bergetai/opencode-auth@1.0.22']);
       expect(content).toContain('$schema');
     });
 

--- a/src/commands/code/init.ts
+++ b/src/commands/code/init.ts
@@ -16,7 +16,7 @@ import { SpawnCommandRunner } from './adapters/spawn-command-runner.js';
 import { configureAuth } from './auth-sync.js';
 import { CancelledError, CommandFailedError, PrerequisiteError } from './errors';
 
-const OPENCODE_PLUGIN = '@bergetai/opencode-auth@1.0.21';
+const OPENCODE_PLUGIN = '@bergetai/opencode-auth@1.0.22';
 const PI_PROVIDER = 'npm:@bergetai/pi-provider';
 const OPENCODE_PLUGIN_NAME = '@bergetai/opencode-auth';
 const PI_PROVIDER_NAME = '@bergetai/pi-provider';


### PR DESCRIPTION
## Summary

Bump `@bergetai/opencode-auth` from `1.0.21` to `1.0.22`.

### Why

v1.0.22 adds `modalities: { input: ['text', 'image'], output: ['text'] }` for Kimi K2.6, which was the missing piece for vision support in OpenCode. Verified working locally.