### PR TITLE
chore: update code command description to be tool-agnostic

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -10,7 +10,7 @@ import { runInitCommand } from './code/init';
 export function registerCodeCommands(program: Command): void {
   const code = program
     .command(COMMAND_GROUPS.CODE)
-    .description('AI-powered coding assistant with OpenCode');
+    .description('Configure Berget AI coding tools');
 
   code
     .command(SUBCOMMANDS.CODE.INIT)

--- a/src/constants/command-structure.ts
+++ b/src/constants/command-structure.ts
@@ -196,7 +196,7 @@ export const COMMAND_DESCRIPTIONS = {
   [COMMAND_GROUPS.CLUSTERS]: 'Manage Kubernetes clusters',
 
   // Code group
-  [COMMAND_GROUPS.CODE]: 'AI-powered coding assistant with OpenCode',
+  [COMMAND_GROUPS.CODE]: 'Configure Berget AI coding tools',
   // Flux group
   [COMMAND_GROUPS.FLUX]: 'Manage Flux CD',
   // Helm group


### PR DESCRIPTION
## Summary

Update `berget code` description from 'AI-powered coding assistant with OpenCode' to 'Configure Berget AI coding tools'.

### Why

`berget code` supports multiple tools (OpenCode, Pi, and more coming), so the description should not reference a specific tool.