### PR TITLE
fix: revert to ubuntu-latest (public repo)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: [infra-runner-set]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: [infra-runner-set]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: [infra-runner-set]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [22]


### PR DESCRIPTION
GitHub blocks self-hosted runners on public repos by default (security risk — anyone can fork and run code on our runners). Revert to ubuntu-latest.