### PR TITLE
feat: update default model to Kimi K2.6 for opencode init

### DIFF
--- a/src/utils/config-loader.ts
+++ b/src/utils/config-loader.ts
@@ -139,14 +139,14 @@ export class ConfigLoader {
       const config = this.loadConfig();
 
       // Extract from config or fall back to defaults
-      const primary = config.model || 'berget/glm-4.7';
+      const primary = config.model || 'berget/kimi-k2.6';
       const small = config.small_model || 'berget/gpt-oss';
 
       return { primary, small };
     } catch {
       // Fallback to defaults when no config exists (init scenario)
       return {
-        primary: 'berget/glm-4.7',
+        primary: 'berget/kimi-k2.6',
         small: 'berget/gpt-oss',
       };
     }
@@ -190,9 +190,9 @@ export class ConfigLoader {
 
     // Fallback to defaults
     return {
-      'glm-4.7': {
-        limit: { context: 90_000, output: 4000 },
-        name: 'GLM-4.7',
+      'kimi-k2.6': {
+        limit: { context: 256_000, output: 16_000 },
+        name: 'Kimi K2.6',
       },
       'gpt-oss': {
         limit: { context: 128_000, output: 4000 },


### PR DESCRIPTION
## Summary

Updates the default model used when initializing OpenCode via `berget code init` from GLM-4.7 to Kimi K2.6, based on customer feedback and model performance.

## Changes

- Changed default primary model from `berget/glm-4.7` to `berget/kimi-k2.6`
- Updated fallback model config in `getModelConfig()`
- Updated provider models list to include Kimi K2.6 with correct context/output limits (256k/16k)
- Removed GLM-4.7 from fallback defaults

## Why

Customer feedback indicated confusion about which model to use. Kimi K2.6 has shown excellent performance for coding tasks, especially frontend development, and should be the recommended default.

## Testing

- [ ] Run `berget code init` in a fresh directory and verify `opencode.json` uses `berget/kimi-k2.6`
- [ ] Verify model config loads correctly when no existing config is present
