### PR TITLE
feat: update default model to Kimi K2.6 for opencode init

### DIFF
--- a/src/commands/code/api-key-handler.ts
+++ b/src/commands/code/api-key-handler.ts
@@ -1,0 +1,277 @@
+/**
+ * API key handling logic for code commands
+ * Handles key selection, creation, and rotation
+ */
+
+import chalk from 'chalk'
+import readline from 'readline'
+import { ApiKeyService, CreateApiKeyOptions } from '../../services/api-key-service'
+import { AuthService } from '../../services/auth-service'
+import { COMMAND_GROUPS, SUBCOMMANDS } from '../../constants/command-structure'
+import { handleError } from '../../utils/error-handler'
+import { confirm, getInput } from './helpers'
+import type { ApiKeyResult, CodeCommandOptions } from './types'
+
+/**
+ * Check authentication status
+ * Returns true if authenticated or has API key in env
+ */
+export async function checkAuthentication(): Promise<{
+  authenticated: boolean
+  hasEnvKey: boolean
+}> {
+  // Check if we have an API key in environment first
+  if (process.env.BERGET_API_KEY) {
+    return { authenticated: true, hasEnvKey: true }
+  }
+
+  // Only require authentication if we don't have an API key
+  try {
+    const authService = AuthService.getInstance()
+    await authService.whoami()
+    return { authenticated: true, hasEnvKey: false }
+  } catch {
+    return { authenticated: false, hasEnvKey: false }
+  }
+}
+
+/**
+ * Print authentication error and guidance
+ */
+export function printAuthenticationError(): void {
+  console.log(chalk.red('❌ Not authenticated with Berget AI.'))
+  console.log(chalk.blue('To get started, you have two options:'))
+  console.log('')
+  console.log(chalk.yellow('Option 1: Use an existing API key (recommended)'))
+  console.log(chalk.cyan('  Set BERGET_API_KEY environment variable:'))
+  console.log(chalk.dim('    export BERGET_API_KEY=your_api_key_here'))
+  console.log(chalk.cyan('  Or create a .env file in your project:'))
+  console.log(chalk.dim('    echo "BERGET_API_KEY=your_api_key_here" > .env'))
+  console.log('')
+  console.log(chalk.yellow('Option 2: Login and create a new API key'))
+  console.log(chalk.cyan('  berget auth login'))
+  console.log(chalk.cyan(`  berget ${COMMAND_GROUPS.CODE} ${SUBCOMMANDS.CODE.INIT}`))
+  console.log('')
+  console.log(chalk.blue('Then try again.'))
+}
+
+/**
+ * Handle API key selection or creation
+ * Returns the API key and key name
+ */
+export async function handleApiKeySelection(
+  options: CodeCommandOptions,
+  projectName: string
+): Promise<ApiKeyResult | null> {
+  // Check for environment variable first (regardless of automation mode)
+  if (process.env.BERGET_API_KEY) {
+    console.log(chalk.blue('🔑 Using BERGET_API_KEY from environment'))
+    return {
+      apiKey: process.env.BERGET_API_KEY,
+      keyName: `env-key-${projectName}`,
+    }
+  }
+
+  try {
+    const apiKeyService = ApiKeyService.getInstance()
+
+    // List existing API keys
+    if (!options.yes) {
+      console.log(chalk.blue('\n📋 Checking existing API keys...'))
+    }
+    const existingKeys = await apiKeyService.list()
+
+    if (existingKeys.length > 0 && !options.yes) {
+      return await selectExistingOrCreateNew(
+        apiKeyService,
+        existingKeys,
+        projectName,
+        options
+      )
+    } else {
+      // No existing keys or automation mode - create new one
+      return await createNewKey(apiKeyService, projectName, options)
+    }
+  } catch (error) {
+    if (process.env.BERGET_API_KEY) {
+      console.log(
+        chalk.yellow(
+          '⚠️  Could not verify API key with Berget API, but continuing with environment key'
+        )
+      )
+      console.log(
+        chalk.dim('This might be due to network issues or an invalid key')
+      )
+      return {
+        apiKey: process.env.BERGET_API_KEY,
+        keyName: `env-key-${projectName}`,
+      }
+    }
+
+    printApiKeyError(error)
+    return null
+  }
+}
+
+/**
+ * Select an existing key or create a new one
+ */
+async function selectExistingOrCreateNew(
+  apiKeyService: ApiKeyService,
+  existingKeys: Array<{
+    id: number
+    name: string
+    prefix: string
+    created: string
+    lastUsed: string | null
+  }>,
+  projectName: string,
+  options: CodeCommandOptions
+): Promise<ApiKeyResult | null> {
+  console.log(chalk.blue('Found existing API keys:'))
+  console.log(chalk.dim('─'.repeat(60)))
+
+  existingKeys.forEach((key, index) => {
+    console.log(
+      `${chalk.cyan((index + 1).toString())}. ${chalk.bold(key.name)} (${key.prefix}...)`
+    )
+    console.log(
+      chalk.dim(
+        `   Created: ${new Date(key.created).toLocaleDateString('sv-SE')}`
+      )
+    )
+    console.log(
+      chalk.dim(
+        `   Last used: ${key.lastUsed ? new Date(key.lastUsed).toLocaleDateString('sv-SE') : 'Never'}`
+      )
+    )
+    if (index < existingKeys.length - 1) console.log()
+  })
+
+  console.log(chalk.dim('─'.repeat(60)))
+  console.log(chalk.cyan(`${existingKeys.length + 1}. Create a new API key`))
+
+  // Get user choice
+  const choice = await getUserChoice(existingKeys.length + 1)
+  const choiceIndex = parseInt(choice) - 1
+
+  if (choiceIndex >= 0 && choiceIndex < existingKeys.length) {
+    // Use existing key - need to rotate to get actual value
+    return await rotateExistingKey(
+      apiKeyService,
+      existingKeys[choiceIndex],
+      options
+    )
+  } else if (choiceIndex === existingKeys.length) {
+    // Create new key
+    return await createNewKey(apiKeyService, projectName, options)
+  }
+
+  console.log(chalk.red('Invalid selection.'))
+  return null
+}
+
+/**
+ * Get user choice from stdin
+ */
+async function getUserChoice(maxOption: number): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+    rl.question(
+      chalk.blue(`\nSelect an option (1-${maxOption}): `),
+      (answer) => {
+        rl.close()
+        resolve(answer.trim())
+      }
+    )
+  })
+}
+
+/**
+ * Rotate an existing key to get the actual key value
+ */
+async function rotateExistingKey(
+  apiKeyService: ApiKeyService,
+  selectedKey: { id: number; name: string },
+  options: CodeCommandOptions
+): Promise<ApiKeyResult | null> {
+  console.log(
+    chalk.yellow(
+      `\n🔄 Rotating API key "${selectedKey.name}" to get the key value...`
+    )
+  )
+
+  if (
+    await confirm(
+      chalk.yellow('This will invalidate the current key. Continue? (Y/n): '),
+      options.yes
+    )
+  ) {
+    const rotatedKey = await apiKeyService.rotate(selectedKey.id.toString())
+    console.log(chalk.green('✓ API key rotated successfully'))
+    return {
+      apiKey: rotatedKey.key,
+      keyName: selectedKey.name,
+    }
+  }
+
+  console.log(
+    chalk.yellow(
+      'Cancelled. Please select a different option or create a new key.'
+    )
+  )
+  return null
+}
+
+/**
+ * Create a new API key
+ */
+async function createNewKey(
+  apiKeyService: ApiKeyService,
+  projectName: string,
+  options: CodeCommandOptions
+): Promise<ApiKeyResult> {
+  if (!options.yes) {
+    console.log(chalk.yellow('No existing API keys found.'))
+  }
+  console.log(chalk.blue('Creating a new API key...'))
+
+  const defaultKeyName = `opencode-${projectName}-${Date.now()}`
+  const customName = await getInput(
+    chalk.blue(`Enter key name (default: ${defaultKeyName}): `),
+    defaultKeyName,
+    options.yes
+  )
+
+  const createOptions: CreateApiKeyOptions = { name: customName }
+  const keyData = await apiKeyService.create(createOptions)
+  console.log(chalk.green(`✓ Created new API key: ${customName}`))
+
+  return {
+    apiKey: keyData.key,
+    keyName: customName,
+  }
+}
+
+/**
+ * Print API key error and guidance
+ */
+function printApiKeyError(error: unknown): void {
+  console.error(chalk.red('❌ Failed to handle API keys:'))
+  console.log(chalk.blue('This could be due to:'))
+  console.log(chalk.dim('  • Network connectivity issues'))
+  console.log(chalk.dim('  • Invalid authentication credentials'))
+  console.log(chalk.dim('  • API service temporarily unavailable'))
+  console.log('')
+  console.log(chalk.blue('Try using an API key directly:'))
+  console.log(chalk.cyan('  export BERGET_API_KEY=your_api_key_here'))
+  console.log(
+    chalk.cyan(
+      `  berget ${COMMAND_GROUPS.CODE} ${SUBCOMMANDS.CODE.INIT} --yes`
+    )
+  )
+  handleError('API key operation failed', error)
+}

--- a/src/commands/code/config-builder.ts
+++ b/src/commands/code/config-builder.ts
@@ -1,0 +1,240 @@
+/**
+ * OpenCode configuration builder
+ * Creates the opencode.json config structure - single source of truth
+ */
+
+import type { MergeableConfig, AgentConfig, CommandConfig, ProviderConfig } from './types'
+import type { ProviderModelConfig } from '../../utils/config-loader'
+
+interface ModelConfig {
+  primary: string
+  small: string
+}
+
+type ProviderModels = Record<string, ProviderModelConfig>
+
+/**
+ * Create the fullstack agent configuration
+ */
+function createFullstackAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.3,
+    top_p: 0.9,
+    mode: 'primary',
+    permission: { edit: 'allow', bash: 'allow', webfetch: 'allow' },
+    description:
+      'Router/coordinator agent for full-stack development with schema-driven architecture',
+    prompt:
+      'Voice: Scandinavian calm—precise, concise, confident; no fluff. You are Berget Code Fullstack agent. Act as a router and coordinator in a monorepo. Bottom-up schema: database → OpenAPI → generated types. Top-down types: API → UI → components. Use openapi-fetch and Zod at every boundary; compile-time errors are desired when contracts change. Routing rules: if task/paths match /apps/frontend or React (.tsx) → use frontend; if /apps/app or Expo/React Native → app; if /infra, /k8s, flux-system, kustomization.yaml, Helm values → devops; if /services, Koa routers, services/adapters/domain → backend. If ambiguous, remain fullstack and outline the end-to-end plan, then delegate subtasks to the right persona. Security: validate inputs; secrets via FluxCD SOPS/Sealed Secrets. Documentation is generated from code—never duplicated. CRITICAL: When all implementation tasks are complete and ready for merge, ALWAYS invoke @quality subagent to handle testing, building, and complete PR management including URL provision.',
+  }
+}
+
+/**
+ * Create the frontend agent configuration
+ */
+function createFrontendAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.4,
+    top_p: 0.9,
+    mode: 'primary',
+    permission: { edit: 'allow', bash: 'deny', webfetch: 'allow' },
+    note: 'Bash access is denied for frontend persona to prevent shell command execution in UI environments. This restriction enforces security and architectural boundaries.',
+    description:
+      'Builds Scandinavian, type-safe UIs with React, Tailwind, Shadcn.',
+    prompt:
+      'You are Berget Code Frontend agent. Voice: Scandinavian calm—precise, concise, confident. React 18 + TypeScript. Tailwind + Shadcn UI only via the design system (index.css, tailwind.config.ts). Use semantic tokens for color/spacing/typography/motion; never ad-hoc classes or inline colors. Components are pure and responsive; props-first data; minimal global state (Zustand/Jotai). Accessibility and keyboard navigation mandatory. Mock data only at init under /data via typed hooks (e.g., useProducts() reading /data/products.json). Design: minimal, balanced, quiet motion. CRITICAL: When all frontend implementation tasks are complete and ready for merge, ALWAYS invoke @quality subagent to handle testing, building, and complete PR management including URL provision.',
+  }
+}
+
+/**
+ * Create the backend agent configuration
+ */
+function createBackendAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.3,
+    top_p: 0.9,
+    mode: 'primary',
+    permission: { edit: 'allow', bash: 'allow', webfetch: 'allow' },
+    description:
+      'Functional, modular Koa + TypeScript services; schema-first with code quality focus.',
+    prompt:
+      'You are Berget Code Backend agent. Voice: Scandinavian calm—precise, concise, confident. TypeScript + Koa. Prefer many small pure functions; avoid big try/catch blocks. Routes thin; logic in services/adapters/domain. Validate with Zod; auto-generate OpenAPI. Adapters isolate external systems; domain never depends on framework. Test with supertest; idempotent and stateless by default. Each microservice emits an OpenAPI contract; changes propagate upward to types. Code Quality & Refactoring Principles: Apply Single Responsibility Principle, fail fast with explicit errors, eliminate code duplication, remove nested complexity, use descriptive error codes, keep functions under 30 lines. Always leave code cleaner and more readable than you found it. CRITICAL: When all backend implementation tasks are complete and ready for merge, ALWAYS invoke @quality subagent to handle testing, building, and complete PR management including URL provision.',
+  }
+}
+
+/**
+ * Create the devops agent configuration
+ */
+function createDevopsAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.3,
+    top_p: 0.8,
+    mode: 'primary',
+    permission: { edit: 'allow', bash: 'allow', webfetch: 'allow' },
+    description:
+      'Declarative GitOps infra with FluxCD, Kustomize, Helm, operators.',
+    prompt:
+      'You are Berget Code DevOps agent. Voice: Scandinavian calm—precise, concise, confident. Start simple: k8s/{deployment,service,ingress}. Add FluxCD sync to repo and image automation. Use Kustomize bases/overlays (staging, production). Add dependencies via Helm from upstream sources; prefer native operators when available (CloudNativePG, cert-manager, external-dns). SemVer with -rc tags keeps CI environments current. Observability with Prometheus/Grafana. No manual kubectl in production—Git is the source of truth. For testing, building, and PR management, use @quality subagent.',
+  }
+}
+
+/**
+ * Create the app agent configuration
+ */
+function createAppAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.4,
+    top_p: 0.9,
+    mode: 'primary',
+    permission: { edit: 'allow', bash: 'deny', webfetch: 'allow' },
+    note: 'Bash access is denied for app persona to prevent shell command execution in mobile/Expo environments. This restriction enforces security and architectural boundaries.',
+    description:
+      'Expo + React Native apps; props-first, offline-aware, shared tokens.',
+    prompt:
+      'You are Berget Code App agent. Voice: Scandinavian calm—precise, concise, confident. Expo + React Native + TypeScript. Structure by components/hooks/services/navigation. Components are pure; data via props; refactor shared logic into hooks/stores. Share tokens with frontend. Mock data in /data via typed hooks; later replace with live APIs. Offline via SQLite/MMKV; notifications via Expo. Request permissions only when needed. Subtle, meaningful motion; light/dark parity. For testing, building, and PR management, use @quality subagent.',
+  }
+}
+
+/**
+ * Create the security agent configuration
+ */
+function createSecurityAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.2,
+    top_p: 0.8,
+    mode: 'subagent',
+    permission: { edit: 'deny', bash: 'allow', webfetch: 'allow' },
+    description:
+      'Security specialist for pentesting, OWASP compliance, and vulnerability assessments.',
+    prompt:
+      'Voice: Scandinavian calm—precise, concise, confident. You are Berget Code Security agent. Expert in application security, penetration testing, and OWASP standards. Core responsibilities: Conduct security assessments and penetration tests, Validate OWASP Top 10 compliance, Review code for security vulnerabilities, Implement security headers and Content Security Policy (CSP), Audit API security, Check for sensitive data exposure, Validate input sanitization and output encoding, Assess dependency security and supply chain risks. Tools and techniques: OWASP ZAP, Burp Suite, security linters, dependency scanners, manual code review. Always provide specific, actionable security recommendations with priority levels. Workflow: Always follow branch_strategy and commit_convention from workflow section. Never work directly in main. Agent awareness: Review code from all personas (frontend, backend, app, devops). If implementation changes are needed, suggest <tab> to switch to appropriate persona after security assessment.',
+  }
+}
+
+/**
+ * Create the quality agent configuration
+ */
+function createQualityAgent(model: string): AgentConfig {
+  return {
+    model,
+    temperature: 0.1,
+    top_p: 0.9,
+    mode: 'subagent',
+    permission: { edit: 'allow', bash: 'allow', webfetch: 'allow' },
+    description:
+      'Quality assurance specialist for testing, building, and complete PR management.',
+    prompt:
+      'Voice: Scandinavian calm—precise, concise, confident. You are Berget Code Quality agent. Specialist in code quality assurance, testing, building, and complete pull request lifecycle management.\n\nCore responsibilities:\n  - Run comprehensive test suites (npm test, npm run test, jest, vitest)\n  - Execute build processes (npm run build, webpack, vite, tsc)\n  - Create and manage pull requests with proper descriptions\n  - Handle merge conflicts and keep main updated\n  - Monitor GitHub for reviewer comments and address them\n  - Ensure code quality standards are met\n  - Validate linting and formatting (npm run lint, prettier)\n  - Check test coverage and performance benchmarks\n  - Handle CI/CD pipeline validation\n\nComplete PR Workflow:\n  1. Ensure all tests pass: npm test\n  2. Build successfully: npm run build\n  3. Commit all changes with proper message\n  4. Push to feature branch\n  5. Update main branch and handle merge conflicts\n  6. Create or update PR with comprehensive description\n  7. Monitor for reviewer comments\n  8. Address feedback and push updates\n  9. Always provide PR URL for user review\n\nEssential CLI commands:\n  - npm test or npm run test (run test suite)\n  - npm run build (build project)\n  - npm run lint (run linting)\n  - npm run format (format code)\n  - npm run test:coverage (check coverage)\n  - git add . && git commit -m "message" && git push (commit and push)\n  - git checkout main && git pull origin main (update main)\n  - git checkout feature-branch && git merge main (handle conflicts)\n  - gh pr create --title "title" --body "body" (create PR)\n  - gh pr view --comments (check PR comments)\n  - gh pr edit --title "title" --body "body" (update PR)\n\nPR Creation Process:\n  - Always include clear summary of changes\n  - List technical details and improvements\n  - Include testing and validation results\n  - Add any breaking changes or migration notes\n  - Provide PR URL immediately after creation\n\nMerge Conflict Resolution:\n  - Always update main before creating PR\n  - Resolve conflicts in feature branch\n  - Test after resolving conflicts\n  - Push resolved changes\n\nAlways provide specific command examples and wait for processes to complete before proceeding.',
+  }
+}
+
+/**
+ * Create command configurations
+ */
+function createCommands(): Record<string, CommandConfig> {
+  return {
+    fullstack: {
+      description: 'Switch to Fullstack (router)',
+      template: '{{input}}',
+      agent: 'fullstack',
+    },
+    route: {
+      description:
+        'Let Fullstack auto-route to the right persona based on files/intent',
+      template: 'ROUTE {{input}}',
+      agent: 'fullstack',
+      subtask: true,
+    },
+    frontend: {
+      description: 'Switch to Frontend persona',
+      template: '{{input}}',
+      agent: 'frontend',
+    },
+    backend: {
+      description: 'Switch to Backend persona',
+      template: '{{input}}',
+      agent: 'backend',
+    },
+    devops: {
+      description: 'Switch to DevOps persona',
+      template: '{{input}}',
+      agent: 'devops',
+    },
+    app: {
+      description: 'Switch to App persona',
+      template: '{{input}}',
+      agent: 'app',
+    },
+    security: {
+      description:
+        'Switch to Security persona for pentesting and OWASP compliance',
+      template: '{{input}}',
+      agent: 'security',
+    },
+    quality: {
+      description:
+        'Switch to Quality agent for testing, building, and PR management',
+      template: '{{input}}',
+      agent: 'quality',
+    },
+  }
+}
+
+/**
+ * Create provider configuration
+ */
+function createProvider(providerModels: ProviderModels): Record<string, ProviderConfig> {
+  return {
+    berget: {
+      npm: '@ai-sdk/openai-compatible',
+      name: 'Berget AI',
+      options: {
+        baseURL: 'https://api.berget.ai/v1',
+        apiKey: '{env:BERGET_API_KEY}',
+      },
+      models: providerModels,
+    },
+  }
+}
+
+/**
+ * Create complete OpenCode configuration
+ * This is the single source of truth for config structure
+ */
+export function createOpenCodeConfig(
+  modelConfig: ModelConfig,
+  providerModels: ProviderModels,
+  latestAgentConfig?: Record<string, AgentConfig>
+): MergeableConfig {
+  const model = modelConfig.primary
+
+  return {
+    $schema: 'https://opencode.ai/config.json',
+    username: 'berget-code',
+    theme: 'berget-dark',
+    share: 'manual',
+    autoupdate: true,
+    model: modelConfig.primary,
+    small_model: modelConfig.small,
+    agent: {
+      fullstack: createFullstackAgent(model),
+      frontend: createFrontendAgent(model),
+      backend: createBackendAgent(model),
+      devops: latestAgentConfig?.devops || createDevopsAgent(model),
+      app: createAppAgent(model),
+      security: createSecurityAgent(model),
+      quality: createQualityAgent(model),
+    },
+    command: createCommands(),
+    watcher: {
+      ignore: ['node_modules', 'dist', '.git', 'coverage'],
+    },
+    provider: createProvider(providerModels),
+  }
+}

--- a/src/commands/code/config-merger.ts
+++ b/src/commands/code/config-merger.ts
@@ -1,0 +1,145 @@
+/**
+ * Configuration merge logic for OpenCode
+ * Handles AI-powered and fallback merging of configurations
+ */
+
+import chalk from 'chalk'
+import { createAuthenticatedClient } from '../../client'
+import { getModelConfig } from '../../utils/config-loader'
+import type { MergeableConfig } from './types'
+
+/**
+ * Merge opencode configurations using chat completions API
+ */
+export async function mergeConfigurations(
+  currentConfig: MergeableConfig,
+  latestConfig: MergeableConfig
+): Promise<MergeableConfig> {
+  try {
+    const client = createAuthenticatedClient()
+    const modelConfig = getModelConfig()
+
+    console.log(chalk.blue('🤖 Using AI to merge configurations...'))
+
+    const mergePrompt = `You are a configuration merge specialist. Merge these two OpenCode configurations:
+
+CURRENT CONFIG (user's customizations):
+${JSON.stringify(currentConfig, null, 2)}
+
+LATEST CONFIG (new updates):
+${JSON.stringify(latestConfig, null, 2)}
+
+Merge rules:
+1. Preserve ALL user customizations from current config
+2. Add ALL new features and improvements from latest config  
+3. For conflicts, prefer user's customizations but add new latest features
+4. Maintain valid JSON structure
+5. Keep the merged configuration complete and functional
+
+Return ONLY the merged JSON configuration, no explanations.`
+
+    const response = await client.POST('/v1/chat/completions', {
+      body: {
+        model: modelConfig.primary,
+        messages: [
+          {
+            role: 'user',
+            content: mergePrompt,
+          },
+        ],
+        temperature: 0.1,
+        max_tokens: 8000,
+      },
+    })
+
+    if (response.error) {
+      console.warn(chalk.yellow('⚠️  AI merge failed, using fallback merge'))
+      return fallbackMerge(currentConfig, latestConfig)
+    }
+
+    const content = response.data?.choices?.[0]?.message?.content
+    if (!content) {
+      console.warn(chalk.yellow('⚠️  No AI response, using fallback merge'))
+      return fallbackMerge(currentConfig, latestConfig)
+    }
+
+    try {
+      const mergedConfig = JSON.parse(content.trim())
+      console.log(chalk.green('✓ AI merge completed successfully'))
+      return mergedConfig
+    } catch {
+      console.warn(
+        chalk.yellow('⚠️  AI response invalid, using fallback merge')
+      )
+      return fallbackMerge(currentConfig, latestConfig)
+    }
+  } catch {
+    console.warn(chalk.yellow('⚠️  AI merge unavailable, using fallback merge'))
+    return fallbackMerge(currentConfig, latestConfig)
+  }
+}
+
+/**
+ * Fallback merge logic when AI merge is unavailable
+ */
+export function fallbackMerge(
+  currentConfig: MergeableConfig,
+  latestConfig: MergeableConfig
+): MergeableConfig {
+  console.log(chalk.blue('🔀 Using fallback merge logic...'))
+
+  const merged: MergeableConfig = { ...latestConfig }
+
+  // Preserve user customizations
+  if (currentConfig.theme && currentConfig.theme !== latestConfig.theme) {
+    merged.theme = currentConfig.theme
+  }
+
+  if (currentConfig.share && currentConfig.share !== latestConfig.share) {
+    merged.share = currentConfig.share
+  }
+
+  // Merge custom agents while preserving new ones
+  if (currentConfig.agent && latestConfig.agent) {
+    merged.agent = { ...latestConfig.agent }
+
+    // Add any custom agents from current config
+    Object.keys(currentConfig.agent).forEach((agentName) => {
+      if (!latestConfig.agent![agentName]) {
+        merged.agent![agentName] = currentConfig.agent![agentName]
+        console.log(chalk.cyan(`  • Preserved custom agent: ${agentName}`))
+      }
+    })
+  }
+
+  // Merge custom commands while preserving new ones
+  if (currentConfig.command && latestConfig.command) {
+    merged.command = { ...latestConfig.command }
+
+    Object.keys(currentConfig.command).forEach((commandName) => {
+      if (!latestConfig.command![commandName]) {
+        merged.command![commandName] = currentConfig.command![commandName]
+        console.log(chalk.cyan(`  • Preserved custom command: ${commandName}`))
+      }
+    })
+  }
+
+  // Preserve custom provider settings if user has modified them
+  if (currentConfig.provider && latestConfig.provider) {
+    merged.provider = { ...latestConfig.provider }
+
+    // Deep merge provider settings
+    Object.keys(currentConfig.provider).forEach((providerName) => {
+      if (merged.provider![providerName]) {
+        merged.provider![providerName] = {
+          ...merged.provider![providerName],
+          ...currentConfig.provider![providerName],
+        }
+      } else {
+        merged.provider![providerName] = currentConfig.provider![providerName]
+      }
+    })
+  }
+
+  return merged
+}

--- a/src/commands/code/documentation-generator.ts
+++ b/src/commands/code/documentation-generator.ts
@@ -1,0 +1,227 @@
+/**
+ * Documentation generator for AGENTS.md
+ * Single source of truth for agent documentation
+ */
+
+import * as fs from 'fs'
+import { writeFile } from 'fs/promises'
+import path from 'path'
+import chalk from 'chalk'
+
+/**
+ * Generate the AGENTS.md content
+ * This is the single source of truth for agent documentation
+ */
+export function createAgentsMdContent(projectName: string): string {
+  return `# Berget Code Agents
+
+This document describes the specialized agents available in this project for use with OpenCode.
+
+## Available Agents
+
+### Primary Agents
+
+#### fullstack
+Router/coordinator agent for full-stack development with schema-driven architecture. Handles routing between different personas based on file paths and task requirements.
+
+**Use when:**
+- Working across multiple parts of a monorepo
+- Need to coordinate between frontend, backend, devops, and app
+- Starting new projects and need to determine tech stack
+
+**Key features:**
+- Schema-driven development (database → OpenAPI → types)
+- Automatic routing to appropriate persona
+- Tech stack discovery and recommendations
+
+#### frontend
+Builds Scandinavian, type-safe UIs with React, Tailwind, and Shadcn.
+
+**Use when:**
+- Working with React components (.tsx files)
+- Frontend development in /apps/frontend
+- UI/UX implementation
+
+**Key features:**
+- Design system integration
+- Semantic tokens and accessibility
+- Props-first component architecture
+
+#### backend
+Functional, modular Koa + TypeScript services with schema-first approach and code quality focus.
+
+**Use when:**
+- Working with Koa routers and services
+- Backend development in /services
+- API development and database work
+
+**Key features:**
+- Zod validation and OpenAPI generation
+- Code quality and refactoring principles
+- PR workflow integration
+
+#### devops
+Declarative GitOps infrastructure with FluxCD, Kustomize, Helm, and operators.
+
+**Use when:**
+- Working with Kubernetes manifests
+- Infrastructure in /infra or /k8s
+- CI/CD and deployment configurations
+
+**Key features:**
+- GitOps workflows
+- Operator-first approach
+- SemVer with release candidates
+
+**Helm Values Configuration Process:**
+1. Documentation First Approach: Always fetch official documentation from Artifact Hub/GitHub for the specific chart version before writing values. Search Artifact Hub for exact chart version documentation, check the chart's GitHub repository for official docs and examples, verify the exact version being used in the deployment.
+2. Validation Requirements: Check for available validation schemas before committing YAML files. Use Helm's built-in validation tools (helm lint, helm template). Validate against JSON schema if available for the chart. Ensure YAML syntax correctness with linters.
+3. Standard Workflow: Identify chart name and exact version. Fetch official documentation from Artifact Hub/GitHub. Check for available schemas and validation tools. Write values according to official documentation. Validate against schema (if available). Test with helm template or helm lint. Commit validated YAML files.
+4. Quality Assurance: Never commit unvalidated Helm values. Use helm dependency update when adding new charts. Test rendering with helm template --dry-run before deployment. Document any custom values with comments referencing official docs.
+
+#### app
+Expo + React Native applications with props-first architecture and offline awareness.
+
+**Use when:**
+- Mobile app development with Expo
+- React Native projects in /apps/app
+- Cross-platform mobile development
+
+**Key features:**
+- Shared design tokens with frontend
+- Offline-first architecture
+- Expo integration
+
+### Subagents
+
+#### security
+Security specialist for penetration testing, OWASP compliance, and vulnerability assessments.
+
+**Use when:**
+- Need security review of code changes
+- OWASP Top 10 compliance checks
+- Vulnerability assessments
+
+**Key features:**
+- OWASP standards compliance
+- Security best practices
+- Actionable remediation strategies
+
+#### quality
+Quality assurance specialist for testing, building, and PR management.
+
+**Use when:**
+- Need to run test suites and build processes
+- Creating or updating pull requests
+- Monitoring GitHub for reviewer comments
+- Ensuring code quality standards
+
+**Key features:**
+- Comprehensive testing and building workflows
+- PR creation and management
+- GitHub integration for reviewer feedback
+- CLI command expertise for quality assurance
+
+## Usage
+
+### Switching Agents
+Use the \`<tab>\` key to cycle through primary agents during a session.
+
+### Manual Agent Selection
+Use commands to switch to specific agents:
+- \`/fullstack\` - Switch to Fullstack agent
+- \`/frontend\` - Switch to Frontend agent  
+- \`/backend\` - Switch to Backend agent
+- \`/devops\` - Switch to DevOps agent
+- \`/app\` - Switch to App agent
+- \`/quality\` - Switch to Quality agent for testing and PR management
+
+### Using Subagents
+Mention subagents with \`@\` symbol:
+- \`@security review this authentication implementation\`
+- \`@quality run tests and create PR for these changes\`
+
+## Routing Rules
+
+The fullstack agent automatically routes tasks based on file patterns:
+
+- \`/apps/frontend\` or \`.tsx\` files → frontend
+- \`/apps/app\` or Expo/React Native → app  
+- \`/infra\`, \`/k8s\`, FluxCD, Helm → devops
+- \`/services\`, Koa routers → backend
+
+## Configuration
+
+All agents are configured in \`opencode.json\` with:
+- Specialized prompts and temperature settings
+- Appropriate tool permissions
+- Model optimizations for their specific tasks
+
+## Environment Setup
+
+Configure \`.env\` with your API key:
+\`\`\`
+BERGET_API_KEY=your_api_key_here
+\`\`\`
+
+## Workflow
+
+All agents follow these principles:
+- Never work directly in main branch
+- Follow branch strategy and commit conventions
+- Create PRs for new functionality
+- Run tests before committing
+- Address reviewer feedback promptly
+
+---
+
+*Generated by berget code init for ${projectName}*
+`
+}
+
+/**
+ * Write AGENTS.md file if it doesn't exist
+ * @returns true if file was created, false if it already existed
+ */
+export async function writeAgentsMd(
+  projectPath: string,
+  projectName: string,
+  forceOverwrite = false
+): Promise<boolean> {
+  const agentsMdPath = path.join(projectPath, 'AGENTS.md')
+
+  if (fs.existsSync(agentsMdPath) && !forceOverwrite) {
+    console.log(
+      chalk.yellow('⚠ AGENTS.md already exists, skipping creation')
+    )
+    return false
+  }
+
+  const content = createAgentsMdContent(projectName)
+  await writeFile(agentsMdPath, content)
+  console.log(chalk.green('✓ Created AGENTS.md'))
+  console.log(chalk.dim('  Documentation for available agents and usage'))
+  return true
+}
+
+/**
+ * Ensure .gitignore contains .env entry
+ */
+export async function ensureGitignoreHasEnv(projectPath: string): Promise<boolean> {
+  const gitignorePath = path.join(projectPath, '.gitignore')
+  let gitignoreContent = ''
+
+  if (fs.existsSync(gitignorePath)) {
+    gitignoreContent = fs.readFileSync(gitignorePath, 'utf8')
+  }
+
+  if (!gitignoreContent.includes('.env')) {
+    gitignoreContent +=
+      (gitignoreContent.endsWith('\n') ? '' : '\n') + '.env\n'
+    await writeFile(gitignorePath, gitignoreContent)
+    console.log(chalk.green('✓ Added .env to .gitignore'))
+    return true
+  }
+
+  return false
+}

--- a/src/commands/code/handlers/index.ts
+++ b/src/commands/code/handlers/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Export all command handlers
+ */
+
+export { handleInitCommand } from './init'
+export { handleRunCommand } from './run'
+export { handleUpdateCommand } from './update'

--- a/src/commands/code/handlers/init.ts
+++ b/src/commands/code/handlers/init.ts
@@ -1,0 +1,189 @@
+/**
+ * Handler for the 'berget code init' command
+ */
+
+import chalk from 'chalk'
+import * as fs from 'fs'
+import { writeFile } from 'fs/promises'
+import path from 'path'
+import { COMMAND_GROUPS, SUBCOMMANDS } from '../../../constants/command-structure'
+import { handleError } from '../../../utils/error-handler'
+import { updateEnvFile } from '../../../utils/env-manager'
+import { getModelConfig, getProviderModels, getConfigLoader } from '../../../utils/config-loader'
+import type { CodeCommandOptions, AgentConfig } from '../types'
+import { confirm, getProjectName } from '../helpers'
+import { ensureOpencodeInstalled } from '../opencode-installer'
+import {
+  checkAuthentication,
+  printAuthenticationError,
+  handleApiKeySelection,
+} from '../api-key-handler'
+import { createOpenCodeConfig } from '../config-builder'
+import { writeAgentsMd, ensureGitignoreHasEnv } from '../documentation-generator'
+
+/**
+ * Handle the init command
+ */
+export async function handleInitCommand(options: CodeCommandOptions): Promise<void> {
+  try {
+    const projectName = options.name || getProjectName()
+    const configPath = path.join(process.cwd(), 'opencode.json')
+
+    // Check if already initialized
+    if (fs.existsSync(configPath) && !options.force) {
+      if (!options.yes) {
+        console.log(chalk.yellow('Project already initialized for OpenCode.'))
+        console.log(chalk.dim(`Config file: ${configPath}`))
+      }
+
+      if (!(await confirm('Do you want to reinitialize? (Y/n): ', options.yes))) {
+        return
+      }
+    }
+
+    // Ensure opencode is installed
+    if (!(await ensureOpencodeInstalled(options.yes))) {
+      return
+    }
+
+    // Check authentication
+    const authStatus = await checkAuthentication()
+    if (!authStatus.authenticated) {
+      printAuthenticationError()
+      return
+    }
+
+    if (authStatus.hasEnvKey) {
+      console.log(
+        chalk.blue('🔑 Using BERGET_API_KEY from environment - no authentication required')
+      )
+    }
+
+    console.log(chalk.cyan(`Initializing OpenCode for project: ${projectName}`))
+
+    // Handle API key selection or creation
+    const apiKeyResult = await handleApiKeySelection(options, projectName)
+    if (!apiKeyResult) {
+      return
+    }
+
+    const { apiKey } = apiKeyResult
+
+    // Prepare paths
+    const envPath = path.join(process.cwd(), '.env')
+
+    // Load latest agent configuration to ensure consistency
+    const latestAgentConfig = await loadLatestAgentConfig()
+    const modelConfig = getModelConfig()
+    const providerModels = getProviderModels()
+
+    // Create opencode.json config
+    const config = createOpenCodeConfig(modelConfig, providerModels, latestAgentConfig)
+
+    // Ask for permission to create config files
+    if (!options.yes) {
+      printConfigurationSummary(configPath, envPath, config)
+    }
+
+    if (!(await confirm('\nCreate configuration files? (Y/n): ', options.yes))) {
+      console.log(chalk.yellow('Configuration file creation cancelled.'))
+      return
+    }
+
+    // Write configuration files
+    await writeConfigurationFiles(envPath, configPath, apiKey, projectName, config)
+
+    // Create AGENTS.md
+    await writeAgentsMd(process.cwd(), projectName)
+
+    // Ensure .gitignore has .env
+    await ensureGitignoreHasEnv(process.cwd())
+
+    console.log(chalk.green('\n✅ Project initialized successfully!'))
+    console.log(chalk.blue('Next steps:'))
+    console.log(
+      chalk.blue(`  berget ${COMMAND_GROUPS.CODE} ${SUBCOMMANDS.CODE.RUN}`)
+    )
+    console.log(chalk.blue('  Or run: opencode'))
+  } catch (error) {
+    handleError('Failed to initialize project', error)
+  }
+}
+
+/**
+ * Load the latest agent configuration from opencode.json
+ */
+async function loadLatestAgentConfig(): Promise<Record<string, AgentConfig> | undefined> {
+  try {
+    const configLoader = getConfigLoader()
+    const config = configLoader.loadConfig()
+    return config.agent
+  } catch {
+    console.warn(chalk.yellow('⚠️  Could not load latest agent config, using fallback'))
+    return undefined
+  }
+}
+
+/**
+ * Print configuration summary before creation
+ */
+function printConfigurationSummary(
+  configPath: string,
+  envPath: string,
+  config: Record<string, unknown>
+): void {
+  console.log(chalk.blue('\nAbout to create configuration files:'))
+  console.log(chalk.dim(`Config: ${configPath}`))
+  console.log(chalk.dim(`Environment: ${envPath}`))
+  console.log(
+    chalk.dim(
+      `Documentation: ${path.join(process.cwd(), 'AGENTS.md')} (if not exists)`
+    )
+  )
+  console.log(
+    chalk.dim(`Environment: ${path.join(process.cwd(), '.env')} will be updated`)
+  )
+  console.log(chalk.dim('This will configure OpenCode to use Berget AI models.'))
+  console.log(chalk.cyan('\n💡 Benefits:'))
+  console.log(
+    chalk.cyan('  • API key stored separately in .env file (not committed to Git)')
+  )
+  console.log(chalk.cyan('  • Easy cost separation per project/customer'))
+  console.log(chalk.cyan('  • Secure key management with environment variables'))
+  console.log(
+    chalk.cyan("  • Project-specific agent documentation (won't overwrite existing)")
+  )
+}
+
+/**
+ * Write configuration files
+ */
+async function writeConfigurationFiles(
+  envPath: string,
+  configPath: string,
+  apiKey: string,
+  projectName: string,
+  config: Record<string, unknown>
+): Promise<void> {
+  try {
+    // Safely update .env file using dotenv
+    await updateEnvFile({
+      envPath,
+      key: 'BERGET_API_KEY',
+      value: apiKey,
+      comment: `Berget AI Configuration for ${projectName} - Generated by berget code init - Do not commit to version control`,
+    })
+
+    // Create opencode.json
+    await writeFile(configPath, JSON.stringify(config, null, 2))
+    console.log(chalk.green('✓ Created opencode.json'))
+    console.log(chalk.dim(`  Model: ${config.model}`))
+    console.log(chalk.dim(`  Small Model: ${config.small_model}`))
+    console.log(chalk.dim(`  Theme: ${config.theme}`))
+    console.log(chalk.dim('  API Key: Stored in .env as BERGET_API_KEY'))
+  } catch (error) {
+    console.error(chalk.red('Failed to create config files:'))
+    handleError('Config file creation failed', error)
+    throw error
+  }
+}

--- a/src/commands/code/handlers/run.ts
+++ b/src/commands/code/handlers/run.ts
@@ -1,0 +1,130 @@
+/**
+ * Handler for the 'berget code run' command
+ */
+
+import chalk from 'chalk'
+import * as fs from 'fs'
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { spawn } from 'child_process'
+import { COMMAND_GROUPS, SUBCOMMANDS } from '../../../constants/command-structure'
+import { handleError } from '../../../utils/error-handler'
+import type { CodeCommandOptions, MergeableConfig } from '../types'
+import { ensureOpencodeInstalled } from '../opencode-installer'
+
+/**
+ * Handle the run command
+ */
+export async function handleRunCommand(
+  prompt: string | undefined,
+  options: CodeCommandOptions
+): Promise<void> {
+  try {
+    const configPath = path.join(process.cwd(), 'opencode.json')
+
+    // Ensure opencode is installed
+    if (!(await ensureOpencodeInstalled(options.yes))) {
+      return
+    }
+
+    let config: MergeableConfig | null = null
+    if (!options.noConfig && fs.existsSync(configPath)) {
+      config = await loadProjectConfig(configPath)
+    }
+
+    if (!config) {
+      console.log(chalk.yellow('No project configuration found.'))
+      console.log(
+        chalk.blue(
+          `Run ${chalk.bold(`berget ${COMMAND_GROUPS.CODE} ${SUBCOMMANDS.CODE.INIT}`)} first.`
+        )
+      )
+      return
+    }
+
+    // Set environment variables for opencode
+    const env = { ...process.env }
+    if (config.apiKey) {
+      env.OPENCODE_API_KEY = config.apiKey as string
+    }
+
+    // Prepare opencode command
+    const opencodeArgs = buildOpencodeArgs(prompt, options, config)
+
+    console.log(chalk.cyan('Starting OpenCode...'))
+
+    // Spawn opencode process
+    spawnOpencode(opencodeArgs, env)
+  } catch (error) {
+    handleError('Failed to run OpenCode', error)
+  }
+}
+
+/**
+ * Load project configuration from opencode.json
+ */
+async function loadProjectConfig(configPath: string): Promise<MergeableConfig | null> {
+  try {
+    const configContent = await readFile(configPath, 'utf8')
+    const config = JSON.parse(configContent) as MergeableConfig
+    console.log(chalk.dim(`Loaded config for project: ${config.projectName || 'unknown'}`))
+    console.log(
+      chalk.dim(
+        `Models: Analysis=${config.analysisModel || 'default'}, Build=${config.buildModel || 'default'}`
+      )
+    )
+    return config
+  } catch {
+    console.log(chalk.yellow('Warning: Failed to load opencode.json'))
+    return null
+  }
+}
+
+/**
+ * Build opencode arguments based on options
+ */
+function buildOpencodeArgs(
+  prompt: string | undefined,
+  options: CodeCommandOptions,
+  config: MergeableConfig
+): string[] {
+  const opencodeArgs: string[] = []
+
+  if (prompt) {
+    opencodeArgs.push('run', prompt)
+  }
+
+  // Choose model based on analysis flag or override
+  let selectedModel = options.model || (config.buildModel as string | undefined)
+  if (options.analysis && !options.model) {
+    selectedModel = config.analysisModel as string | undefined
+  }
+
+  if (selectedModel) {
+    opencodeArgs.push('--model', selectedModel)
+  }
+
+  return opencodeArgs
+}
+
+/**
+ * Spawn the opencode process
+ */
+function spawnOpencode(args: string[], env: NodeJS.ProcessEnv): void {
+  const opencode = spawn('opencode', args, {
+    stdio: 'inherit',
+    env: env,
+    shell: true,
+  })
+
+  opencode.on('close', (code) => {
+    if (code !== 0) {
+      console.log(chalk.red(`OpenCode exited with code ${code}`))
+    }
+  })
+
+  opencode.on('error', (error) => {
+    console.error(chalk.red('Failed to start OpenCode:'))
+    console.error(error.message)
+  })
+}

--- a/src/commands/code/handlers/update.ts
+++ b/src/commands/code/handlers/update.ts
@@ -1,0 +1,289 @@
+/**
+ * Handler for the 'berget code update' command
+ */
+
+import chalk from 'chalk'
+import * as fs from 'fs'
+import { readFile, writeFile } from 'fs/promises'
+import path from 'path'
+import { COMMAND_GROUPS, SUBCOMMANDS } from '../../../constants/command-structure'
+import { handleError } from '../../../utils/error-handler'
+import { getModelConfig, getProviderModels, getConfigLoader } from '../../../utils/config-loader'
+import type { CodeCommandOptions, MergeableConfig, AgentConfig } from '../types'
+import { confirm, askChoice, hasGit } from '../helpers'
+import { ensureOpencodeInstalled } from '../opencode-installer'
+import { createOpenCodeConfig } from '../config-builder'
+import { writeAgentsMd } from '../documentation-generator'
+import { mergeConfigurations } from '../config-merger'
+
+/**
+ * Handle the update command
+ */
+export async function handleUpdateCommand(options: CodeCommandOptions): Promise<void> {
+  try {
+    console.log(chalk.cyan('🔄 Updating OpenCode configuration...'))
+
+    // Ensure opencode is installed first
+    if (!(await ensureOpencodeInstalled(options.yes))) {
+      return
+    }
+
+    const configPath = path.join(process.cwd(), 'opencode.json')
+
+    // Check if project is initialized
+    if (!fs.existsSync(configPath)) {
+      console.log(chalk.red('❌ No OpenCode configuration found.'))
+      console.log(
+        chalk.blue(
+          `Run ${chalk.bold(`berget ${COMMAND_GROUPS.CODE} ${SUBCOMMANDS.CODE.INIT}`)} first.`
+        )
+      )
+      return
+    }
+
+    // Read current configuration
+    const currentConfig = await readCurrentConfig(configPath)
+    if (!currentConfig) {
+      return
+    }
+
+    printCurrentConfig(currentConfig)
+
+    // Load latest configuration
+    const latestAgentConfig = await loadLatestAgentConfig()
+    const modelConfig = getModelConfig()
+    const providerModels = getProviderModels()
+    const latestConfig = createOpenCodeConfig(modelConfig, providerModels, latestAgentConfig)
+
+    // Check if update is needed
+    const needsUpdate = JSON.stringify(currentConfig) !== JSON.stringify(latestConfig)
+
+    if (!needsUpdate && !options.force) {
+      console.log(chalk.green('✅ Already using the latest configuration!'))
+      return
+    }
+
+    if (needsUpdate) {
+      printAvailableUpdates(currentConfig, latestConfig, modelConfig)
+    }
+
+    if (options.force) {
+      console.log(chalk.yellow('🔧 Force update requested'))
+    }
+
+    // Print git status info
+    if (!options.yes) {
+      printGitStatus()
+    }
+
+    // Get update strategy choice
+    const mergeChoice = await getUpdateStrategyChoice(options)
+
+    if (!(await confirm(`\nProceed with ${mergeChoice}? (Y/n): `, options.yes))) {
+      console.log(chalk.yellow('Update cancelled.'))
+      return
+    }
+
+    // Perform update
+    await performUpdate(
+      configPath,
+      currentConfig,
+      latestConfig,
+      mergeChoice
+    )
+
+    // Update AGENTS.md if it doesn't exist
+    await writeAgentsMd(process.cwd(), 'updated')
+
+    printSuccessMessage()
+  } catch (error) {
+    handleError('Failed to update OpenCode configuration', error)
+  }
+}
+
+/**
+ * Read current configuration from file
+ */
+async function readCurrentConfig(configPath: string): Promise<MergeableConfig | null> {
+  try {
+    const configContent = await readFile(configPath, 'utf8')
+    return JSON.parse(configContent) as MergeableConfig
+  } catch (error) {
+    console.error(chalk.red('Failed to read current opencode.json:'))
+    handleError('Config read failed', error)
+    return null
+  }
+}
+
+/**
+ * Load the latest agent configuration
+ */
+async function loadLatestAgentConfig(): Promise<Record<string, AgentConfig> | undefined> {
+  try {
+    const configLoader = getConfigLoader()
+    const config = configLoader.loadConfig()
+    return config.agent
+  } catch {
+    console.warn(chalk.yellow('⚠️  Could not load latest agent config, using fallback'))
+    return undefined
+  }
+}
+
+/**
+ * Print current configuration summary
+ */
+function printCurrentConfig(config: MergeableConfig): void {
+  console.log(chalk.blue('📋 Current configuration:'))
+  console.log(chalk.dim(`  Model: ${config.model}`))
+  console.log(chalk.dim(`  Theme: ${config.theme}`))
+  console.log(
+    chalk.dim(`  Agents: ${Object.keys(config.agent || {}).length} configured`)
+  )
+}
+
+/**
+ * Print available updates
+ */
+function printAvailableUpdates(
+  currentConfig: MergeableConfig,
+  latestConfig: MergeableConfig,
+  modelConfig: { primary: string }
+): void {
+  console.log(chalk.blue('\n🔄 Updates available:'))
+
+  // Compare agents
+  const currentAgents = Object.keys(currentConfig.agent || {})
+  const latestAgents = Object.keys(latestConfig.agent || {})
+  const newAgents = latestAgents.filter((agent) => !currentAgents.includes(agent))
+
+  if (newAgents.length > 0) {
+    console.log(chalk.cyan(`  • New agents: ${newAgents.join(', ')}`))
+  }
+
+  // Check for quality agent specifically
+  if (!currentConfig.agent?.quality && latestConfig.agent?.quality) {
+    console.log(chalk.cyan('  • Quality subagent for testing and PR management'))
+  }
+
+  // Check for security subagent mode
+  if (currentConfig.agent?.security?.mode !== 'subagent') {
+    console.log(chalk.cyan('  • Security agent converted to subagent (read-only)'))
+  }
+
+  // Check for model optimizations
+  const primaryModelKey = modelConfig.primary.replace('berget/', '')
+  const bergetModels = currentConfig.provider?.berget?.models as Record<string, { limit?: { context?: number } }> | undefined
+  if (!bergetModels?.[primaryModelKey]?.limit?.context) {
+    console.log(chalk.cyan('  • GLM-4.6 token limits and auto-compaction'))
+  }
+
+  console.log(chalk.cyan('  • Latest agent prompts and improvements'))
+}
+
+/**
+ * Print git status info
+ */
+function printGitStatus(): void {
+  console.log(
+    chalk.blue('\nThis will update your OpenCode configuration with the latest improvements.')
+  )
+
+  const hasGitRepo = hasGit()
+  if (!hasGitRepo) {
+    console.log(
+      chalk.yellow('⚠️  No .git repository detected - backup will be created')
+    )
+  } else {
+    console.log(chalk.green('✓ Git repository detected - changes are tracked'))
+  }
+}
+
+/**
+ * Get update strategy choice from user
+ */
+async function getUpdateStrategyChoice(
+  options: CodeCommandOptions
+): Promise<'replace' | 'merge'> {
+  console.log(chalk.blue('\nChoose update strategy:'))
+  console.log(
+    chalk.cyan('1) Replace - Use latest configuration (your customizations will be lost)')
+  )
+  console.log(
+    chalk.cyan('2) Merge  - Combine latest updates with your customizations (recommended)')
+  )
+
+  if (options.yes) {
+    return 'merge'
+  }
+
+  const choice = await askChoice(
+    '\nYour choice (1-2, default: 2): ',
+    ['replace', 'merge'],
+    'merge'
+  )
+  return choice as 'replace' | 'merge'
+}
+
+/**
+ * Perform the configuration update
+ */
+async function performUpdate(
+  configPath: string,
+  currentConfig: MergeableConfig,
+  latestConfig: MergeableConfig,
+  mergeChoice: 'replace' | 'merge'
+): Promise<void> {
+  let backupPath: string | null = null
+
+  // Create backup if no git
+  if (!hasGit()) {
+    backupPath = `${configPath}.backup.${Date.now()}`
+    await writeFile(backupPath, JSON.stringify(currentConfig, null, 2))
+    console.log(
+      chalk.green(`✓ Backed up current config to ${path.basename(backupPath)}`)
+    )
+  }
+
+  try {
+    let finalConfig: MergeableConfig
+
+    if (mergeChoice === 'merge') {
+      finalConfig = await mergeConfigurations(currentConfig, latestConfig)
+      console.log(chalk.green('✓ Merged configurations with latest updates'))
+    } else {
+      finalConfig = latestConfig
+      console.log(chalk.green('✓ Replaced with latest configuration'))
+    }
+
+    // Write final configuration
+    await writeFile(configPath, JSON.stringify(finalConfig, null, 2))
+    console.log(chalk.green(`✓ Updated opencode.json with ${mergeChoice} strategy`))
+  } catch (error) {
+    console.error(chalk.red('Failed to update configuration:'))
+    handleError('Update failed', error)
+
+    // Restore from backup if update failed
+    try {
+      await writeFile(configPath, JSON.stringify(currentConfig, null, 2))
+      console.log(chalk.yellow('📁 Restored original configuration from backup'))
+    } catch {
+      console.error(chalk.red('Failed to restore backup'))
+    }
+    throw error
+  }
+}
+
+/**
+ * Print success message with new features
+ */
+function printSuccessMessage(): void {
+  console.log(chalk.green('\n✅ Update completed successfully!'))
+  console.log(chalk.blue('New features available:'))
+  console.log(chalk.cyan('  • @quality subagent for testing and PR management'))
+  console.log(chalk.cyan('  • @security subagent for security reviews'))
+  console.log(chalk.cyan('  • Improved agent prompts and routing'))
+  console.log(chalk.cyan('  • GLM-4.6 token optimizations'))
+  console.log(chalk.blue('\nTry these new commands:'))
+  console.log(chalk.cyan('  @quality run tests and create PR'))
+  console.log(chalk.cyan('  @security review this code'))
+}

--- a/src/commands/code/helpers.ts
+++ b/src/commands/code/helpers.ts
@@ -1,0 +1,130 @@
+/**
+ * User interaction helper functions for the code command module
+ */
+
+import readline from 'readline'
+import * as fs from 'fs'
+import path from 'path'
+
+/**
+ * Check if current directory has git
+ */
+export function hasGit(): boolean {
+  try {
+    return fs.existsSync(path.join(process.cwd(), '.git'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Helper function to get user confirmation
+ */
+export async function confirm(
+  question: string,
+  autoYes = false
+): Promise<boolean> {
+  if (autoYes) {
+    return true
+  }
+
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(
+        answer.toLowerCase() === 'y' ||
+          answer.toLowerCase() === 'yes' ||
+          answer === ''
+      )
+    })
+  })
+}
+
+/**
+ * Helper function to get user choice from options
+ */
+export async function askChoice(
+  question: string,
+  options: string[],
+  defaultChoice?: string
+): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+
+    rl.question(question, (answer) => {
+      rl.close()
+
+      const trimmed = answer.trim().toLowerCase()
+
+      // Handle numeric input (1, 2, etc.)
+      const numericIndex = parseInt(trimmed) - 1
+      if (numericIndex >= 0 && numericIndex < options.length) {
+        resolve(options[numericIndex])
+        return
+      }
+
+      // Handle text input
+      const matchingOption = options.find((option) =>
+        option.toLowerCase().startsWith(trimmed)
+      )
+
+      if (matchingOption) {
+        resolve(matchingOption)
+      } else if (defaultChoice) {
+        resolve(defaultChoice)
+      } else {
+        resolve(options[0]) // Default to first option
+      }
+    })
+  })
+}
+
+/**
+ * Helper function to get user input
+ */
+export async function getInput(
+  question: string,
+  defaultValue: string,
+  autoYes = false
+): Promise<string> {
+  if (autoYes) {
+    return defaultValue
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise<string>((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer.trim() || defaultValue)
+    })
+  })
+}
+
+/**
+ * Get project name from current directory or package.json
+ */
+export function getProjectName(): string {
+  try {
+    const packageJsonPath = path.join(process.cwd(), 'package.json')
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8')
+      const packageJson = JSON.parse(packageJsonContent)
+      return packageJson.name || path.basename(process.cwd())
+    }
+  } catch {
+    // Ignore error and fallback to directory name
+  }
+  return path.basename(process.cwd())
+}

--- a/src/commands/code/index.ts
+++ b/src/commands/code/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Code command module exports
+ */
+
+// Types
+export type {
+  CodeCommandOptions,
+  MergeableConfig,
+  ApiKeyResult,
+} from './types'
+
+// Handlers
+export {
+  handleInitCommand,
+  handleRunCommand,
+  handleUpdateCommand,
+} from './handlers'
+
+// Utilities
+export { createOpenCodeConfig } from './config-builder'
+export { mergeConfigurations, fallbackMerge } from './config-merger'
+export { writeAgentsMd, ensureGitignoreHasEnv } from './documentation-generator'
+export { ensureOpencodeInstalled, checkOpencodeInstalled } from './opencode-installer'
+export { handleApiKeySelection, checkAuthentication } from './api-key-handler'
+export { confirm, askChoice, getInput, getProjectName, hasGit } from './helpers'

--- a/src/commands/code/opencode-installer.ts
+++ b/src/commands/code/opencode-installer.ts
@@ -1,0 +1,115 @@
+/**
+ * OpenCode installation and verification logic
+ */
+
+import chalk from 'chalk'
+import { spawn } from 'child_process'
+import { confirm } from './helpers'
+
+/**
+ * Check if opencode is installed
+ */
+export function checkOpencodeInstalled(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn('opencode', ['--version'], {
+      stdio: 'pipe',
+      shell: true,
+    })
+
+    child.on('close', (code) => {
+      resolve(code === 0)
+    })
+
+    child.on('error', () => {
+      resolve(false)
+    })
+  })
+}
+
+/**
+ * Install opencode via npm
+ */
+export async function installOpencode(): Promise<boolean> {
+  console.log(chalk.cyan('Installing OpenCode via npm...'))
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const install = spawn('npm', ['install', '-g', 'opencode-ai'], {
+        stdio: 'inherit',
+        shell: true,
+      })
+
+      install.on('close', (code) => {
+        if (code === 0) {
+          console.log(chalk.green('✓ OpenCode installed successfully!'))
+          resolve()
+        } else {
+          reject(new Error(`Installation failed with code ${code}`))
+        }
+      })
+
+      install.on('error', reject)
+    })
+
+    // Verify installation
+    const opencodeInstalled = await checkOpencodeInstalled()
+    if (!opencodeInstalled) {
+      console.log(
+        chalk.yellow('Installation completed but opencode command not found.')
+      )
+      console.log(
+        chalk.yellow(
+          'You may need to restart your terminal or check your PATH.'
+        )
+      )
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.error(chalk.red('Failed to install OpenCode:'))
+    console.error(error instanceof Error ? error.message : String(error))
+    console.log(chalk.blue('\nAlternative installation methods:'))
+    console.log(chalk.blue('  curl -fsSL https://opencode.ai/install | bash'))
+    console.log(chalk.blue('  Or visit: https://opencode.ai/docs'))
+    return false
+  }
+}
+
+/**
+ * Ensure opencode is installed, offering to install if not
+ */
+export async function ensureOpencodeInstalled(
+  autoYes = false
+): Promise<boolean> {
+  let opencodeInstalled = await checkOpencodeInstalled()
+  if (!opencodeInstalled) {
+    if (!autoYes) {
+      console.log(chalk.red('OpenCode is not installed.'))
+      console.log(
+        chalk.blue('OpenCode is required for the AI coding assistant.')
+      )
+    }
+
+    if (
+      await confirm(
+        'Would you like to install OpenCode automatically? (Y/n): ',
+        autoYes
+      )
+    ) {
+      opencodeInstalled = await installOpencode()
+    } else {
+      if (!autoYes) {
+        console.log(chalk.blue('\nInstallation cancelled.'))
+        console.log(
+          chalk.blue(
+            'To install manually: curl -fsSL https://opencode.ai/install | bash'
+          )
+        )
+        console.log(chalk.blue('Or visit: https://opencode.ai/docs'))
+      }
+    }
+  }
+
+  return opencodeInstalled
+}

--- a/src/commands/code/types.ts
+++ b/src/commands/code/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Type definitions for the code command module
+ */
+
+// Re-export shared types from config-loader
+export type { AgentConfig, OpenCodeConfig } from '../../utils/config-loader'
+
+/**
+ * Options for code command actions
+ */
+export interface CodeCommandOptions {
+  name?: string
+  force?: boolean
+  yes?: boolean
+  model?: string
+  analysis?: boolean
+  noConfig?: boolean
+  [key: string]: unknown
+}
+
+/**
+ * Command configuration for opencode.json
+ */
+export interface CommandConfig {
+  description: string
+  template: string
+  agent: string
+  subtask?: boolean
+}
+
+/**
+ * Watcher configuration for opencode.json
+ */
+export interface WatcherConfig {
+  ignore: string[]
+}
+
+/**
+ * Provider configuration for opencode.json
+ */
+export interface ProviderConfig {
+  npm: string
+  name: string
+  options: {
+    baseURL: string
+    apiKey: string
+  }
+  models: ProviderModels
+}
+
+/**
+ * Provider models configuration
+ */
+export type ProviderModels = Record<string, unknown>
+
+/**
+ * Extended type for merge operations (more flexible for merging)
+ */
+export interface MergeableConfig {
+  [key: string]: unknown
+  $schema?: string
+  username?: string
+  theme?: string
+  share?: string
+  autoupdate?: boolean
+  model?: string
+  small_model?: string
+  projectName?: string
+  apiKey?: string
+  analysisModel?: string
+  buildModel?: string
+  agent?: Record<string, import('../../utils/config-loader').AgentConfig>
+  command?: Record<string, CommandConfig>
+  watcher?: WatcherConfig
+  provider?: Record<string, ProviderConfig>
+}
+
+/**
+ * Result of API key handling
+ */
+export interface ApiKeyResult {
+  apiKey: string
+  keyName: string
+}


### PR DESCRIPTION
## Summary

Updates the default model used when initializing OpenCode via `berget code init` from GLM-4.7 to Kimi K2.6, based on customer feedback and model performance.

## Changes

- Changed default primary model from `berget/glm-4.7` to `berget/kimi-k2.6`
- Updated fallback model config in `getModelConfig()`
- Updated provider models list to include Kimi K2.6 with correct context/output limits (256k/16k)
- Removed GLM-4.7 from fallback defaults

## Why

Customer feedback indicated confusion about which model to use. Kimi K2.6 has shown excellent performance for coding tasks, especially frontend development, and should be the recommended default.

## Testing

- [ ] Run `berget code init` in a fresh directory and verify `opencode.json` uses `berget/kimi-k2.6`
- [ ] Verify model config loads correctly when no existing config is present
