### PR TITLE
chore: update default model from GLM-4.7 to Kimi K2.6

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -20,7 +20,7 @@ export function registerChatCommands(program: Command): void {
     .command(SUBCOMMANDS.CHAT.RUN)
     .description('Run a chat session with a specified model')
     .argument('[message]', 'Message to send directly (skips interactive mode)')
-    .option('-m, --model <model>', 'Model to use (default: glm-4.7)')
+    .option('-m, --model <model>', 'Model to use (default: kimi-k2.6)')
 
     .option('-t, --temperature <temp>', 'Temperature (0-1)', Number.parseFloat)
     .option('--max-tokens <tokens>', 'Maximum tokens to generate', Number.parseInt)

--- a/src/utils/config-loader.ts
+++ b/src/utils/config-loader.ts
@@ -139,14 +139,14 @@ export class ConfigLoader {
       const config = this.loadConfig();
 
       // Extract from config or fall back to defaults
-      const primary = config.model || 'berget/glm-4.7';
+      const primary = config.model || 'berget/kimi-k2.6';
       const small = config.small_model || 'berget/gpt-oss';
 
       return { primary, small };
     } catch {
       // Fallback to defaults when no config exists (init scenario)
       return {
-        primary: 'berget/glm-4.7',
+        primary: 'berget/kimi-k2.6',
         small: 'berget/gpt-oss',
       };
     }
@@ -190,10 +190,6 @@ export class ConfigLoader {
 
     // Fallback to defaults
     return {
-      'glm-4.7': {
-        limit: { context: 90_000, output: 4000 },
-        name: 'GLM-4.7',
-      },
       'gpt-oss': {
         limit: { context: 128_000, output: 4000 },
         modalities: {
@@ -201,6 +197,10 @@ export class ConfigLoader {
           output: ['text'],
         },
         name: 'GPT-OSS',
+      },
+      'kimi-k2.6': {
+        limit: { context: 256_000, output: 16_000 },
+        name: 'Kimi K2.6',
       },
       'llama-8b': {
         limit: { context: 128_000, output: 4000 },

--- a/tests/commands/chat.test.ts
+++ b/tests/commands/chat.test.ts
@@ -45,7 +45,7 @@ describe('Chat Commands', () => {
   });
 
   describe('chat run command', () => {
-    it('should use berget/glm-4.7 as default model', () => {
+    it('should use berget/kimi-k2.6 as default model', () => {
       const chatCommand = program.commands.find((cmd) => cmd.name() === 'chat');
       const runCommand = chatCommand?.commands.find((cmd) => cmd.name() === 'run');
 
@@ -53,7 +53,7 @@ describe('Chat Commands', () => {
 
       // Check the help text which contains the default model
       const helpText = runCommand?.helpInformation();
-      expect(helpText).toContain('glm-4.7');
+      expect(helpText).toContain('kimi-k2.6');
     });
 
     it('should have streaming enabled by default', () => {

--- a/tests/utils/config-loader.test.ts
+++ b/tests/utils/config-loader.test.ts
@@ -45,7 +45,7 @@ describe('ConfigLoader', () => {
         const modelConfig = configLoader.getModelConfig();
 
         expect(modelConfig).toEqual({
-          primary: 'berget/glm-4.7',
+          primary: 'berget/kimi-k2.6',
           small: 'berget/gpt-oss',
         });
       });
@@ -54,7 +54,7 @@ describe('ConfigLoader', () => {
         const modelConfig = getModelConfig(testConfigPath);
 
         expect(modelConfig).toEqual({
-          primary: 'berget/glm-4.7',
+          primary: 'berget/kimi-k2.6',
           small: 'berget/gpt-oss',
         });
       });
@@ -65,10 +65,6 @@ describe('ConfigLoader', () => {
         const models = configLoader.getProviderModels();
 
         expect(models).toEqual({
-          'glm-4.7': {
-            limit: { context: 90_000, output: 4000 },
-            name: 'GLM-4.7',
-          },
           'gpt-oss': {
             limit: { context: 128_000, output: 4000 },
             modalities: {
@@ -76,6 +72,10 @@ describe('ConfigLoader', () => {
               output: ['text'],
             },
             name: 'GPT-OSS',
+          },
+          'kimi-k2.6': {
+            limit: { context: 256_000, output: 16_000 },
+            name: 'Kimi K2.6',
           },
           'llama-8b': {
             limit: { context: 128_000, output: 4000 },
@@ -88,10 +88,6 @@ describe('ConfigLoader', () => {
         const models = getProviderModels(testConfigPath);
 
         expect(models).toEqual({
-          'glm-4.7': {
-            limit: { context: 90_000, output: 4000 },
-            name: 'GLM-4.7',
-          },
           'gpt-oss': {
             limit: { context: 128_000, output: 4000 },
             modalities: {
@@ -99,6 +95,10 @@ describe('ConfigLoader', () => {
               output: ['text'],
             },
             name: 'GPT-OSS',
+          },
+          'kimi-k2.6': {
+            limit: { context: 256_000, output: 16_000 },
+            name: 'Kimi K2.6',
           },
           'llama-8b': {
             limit: { context: 128_000, output: 4000 },
@@ -229,7 +229,7 @@ describe('ConfigLoader', () => {
       const modelConfig = configLoader.getModelConfig();
 
       expect(modelConfig).toEqual({
-        primary: 'berget/glm-4.7',
+        primary: 'berget/kimi-k2.6',
         small: 'berget/gpt-oss',
       });
     });
@@ -238,10 +238,6 @@ describe('ConfigLoader', () => {
       const models = configLoader.getProviderModels();
 
       expect(models).toEqual({
-        'glm-4.7': {
-          limit: { context: 90_000, output: 4000 },
-          name: 'GLM-4.7',
-        },
         'gpt-oss': {
           limit: { context: 128_000, output: 4000 },
           modalities: {
@@ -249,6 +245,10 @@ describe('ConfigLoader', () => {
             output: ['text'],
           },
           name: 'GPT-OSS',
+        },
+        'kimi-k2.6': {
+          limit: { context: 256_000, output: 16_000 },
+          name: 'Kimi K2.6',
         },
         'llama-8b': {
           limit: { context: 128_000, output: 4000 },
@@ -296,7 +296,7 @@ describe('ConfigLoader', () => {
 
       // And return sensible defaults
       expect(configLoader.getModelConfig()).toEqual({
-        primary: 'berget/glm-4.7',
+        primary: 'berget/kimi-k2.6',
         small: 'berget/gpt-oss',
       });
       expect(configLoader.getAllAgentConfigs()).toEqual({});
@@ -312,7 +312,7 @@ describe('ConfigLoader', () => {
       expect(() => getAllAgentConfigs(testConfigPath)).not.toThrow();
 
       expect(getModelConfig(testConfigPath)).toEqual({
-        primary: 'berget/glm-4.7',
+        primary: 'berget/kimi-k2.6',
         small: 'berget/gpt-oss',
       });
       expect(getAllAgentConfigs(testConfigPath)).toEqual({});


### PR DESCRIPTION
Updates the default primary model fallback across the CLI from `berget/glm-4.7` to `berget/kimi-k2.6`, with provider model specs updated to Kimi K2.6 limits (256k context / 16k output).

### Changes
- `src/utils/config-loader.ts` — primary default model and fallback provider models
- `src/commands/chat.ts` — update help text for the `--model` option
- Update corresponding test expectations in `tests/utils/config-loader.test.ts` and `tests/commands/chat.test.ts`

### Default model comparison
| Model | Context | Output |
|---|---|---|
| GLM-4.7 (old) | 90,000 | 4,000 |
| **Kimi K2.6 (new)** | **256,000** | **16,000** |
