### PR TITLE
refactor(code): extract opencode and pi setup from init.ts

### DIFF
--- a/src/commands/code/init.ts
+++ b/src/commands/code/init.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { applyEdits, modify, parse } from 'jsonc-parser';
 import * as os from 'node:os';
 
 import type { ApiKeyServicePort, AuthServicePort } from './ports/auth-services.js';
@@ -7,7 +6,6 @@ import type { CommandRunner } from './ports/command-runner.js';
 import type { FileStore } from './ports/file-store.js';
 import type { Prompter } from './ports/prompter.js';
 
-import { getAllAgents, toMarkdown, toPiPrompt } from '../../agents/index.js';
 import { ApiKeyService } from '../../services/api-key-service.js';
 import { AuthService } from '../../services/auth-service.js';
 import { ClackPrompter } from './adapters/clack-prompter.js';
@@ -15,11 +13,13 @@ import { FsFileStore } from './adapters/fs-file-store.js';
 import { SpawnCommandRunner } from './adapters/spawn-command-runner.js';
 import { configureAuth } from './auth-sync.js';
 import { CancelledError, CommandFailedError, PrerequisiteError } from './errors.js';
-
-const OPENCODE_PLUGIN = '@bergetai/opencode-auth@1.0.22';
-const PI_PROVIDER = 'npm:@bergetai/pi-provider';
-const OPENCODE_PLUGIN_NAME = '@bergetai/opencode-auth';
-const PI_PROVIDER_NAME = '@bergetai/pi-provider';
+import {
+  getOpencodeLabel,
+  getOpencodeState,
+  initOpenCode,
+  initOpenCodeAgents,
+} from './opencode.js';
+import { getPiLabel, getPiState, initPi, initPiAgent } from './pi.js';
 
 export interface WizardDeps {
   apiKeyService: ApiKeyServicePort;
@@ -95,8 +95,8 @@ export async function runInit(deps: WizardDeps): Promise<void> {
   );
 
   if (tool === 'opencode') {
-    await setupOpenCode({ commands, cwd, files, homeDir, prompter, scope });
-    await setupOpenCodeAgents({ cwd, files, homeDir, prompter, scope });
+    await initOpenCode({ commands, cwd, files, homeDir, prompter, scope });
+    await initOpenCodeAgents({ cwd, files, homeDir, prompter, scope });
 
     if (authResult.authenticated) {
       prompter.note(
@@ -110,8 +110,8 @@ export async function runInit(deps: WizardDeps): Promise<void> {
       );
     }
   } else {
-    await setupPi({ commands, cwd, files, homeDir, prompter, scope });
-    await setupPiAgent({ cwd, files, homeDir, prompter, scope });
+    await initPi({ commands, cwd, files, homeDir, prompter, scope });
+    await initPiAgent({ cwd, files, homeDir, prompter, scope });
 
     if (authResult.authenticated) {
       prompter.note(
@@ -128,8 +128,6 @@ export async function runInit(deps: WizardDeps): Promise<void> {
 
   prompter.outro('Initialization complete!');
 }
-
-// ─── OpenCode ────────────────────────────────────────────────────────────────
 
 export async function runInitCommand(): Promise<void> {
   try {
@@ -157,461 +155,4 @@ export async function runInitCommand(): Promise<void> {
     }
     throw error;
   }
-}
-
-// ─── OpenCode Config Helpers ──────────────────────────────────────────────────
-
-function generateModifiedContent(existingContent: null | string, configPath: string): string {
-  if (configPath.endsWith('.jsonc')) {
-    const content = existingContent || '{}';
-    const parseErrors: any[] = [];
-    const parsed = parse(content, parseErrors, {
-      allowTrailingComma: true,
-      disallowComments: false,
-    });
-
-    let jsConfig: Record<string, any> = {};
-    const canModifyText =
-      parsed !== undefined &&
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      !Array.isArray(parsed);
-
-    if (canModifyText) {
-      jsConfig = parsed as Record<string, any>;
-    }
-
-    const pluginsKey = jsConfig.plugins === undefined ? 'plugin' : 'plugins';
-    const existing: string[] = jsConfig[pluginsKey] || [];
-    const filtered = existing.filter((p: string) => !p.includes(OPENCODE_PLUGIN_NAME));
-    filtered.push(OPENCODE_PLUGIN);
-
-    if (canModifyText) {
-      let modifiedContent = content;
-      const pluginEdits = modify(modifiedContent, [pluginsKey], filtered, {
-        formattingOptions: { insertSpaces: true, tabSize: 2 },
-      });
-      modifiedContent = applyEdits(modifiedContent, pluginEdits);
-
-      if (!jsConfig.$schema) {
-        const schemaEdits = modify(
-          modifiedContent,
-          ['$schema'],
-          'https://opencode.ai/config.json',
-          {
-            formattingOptions: { insertSpaces: true, tabSize: 2 },
-          },
-        );
-        modifiedContent = applyEdits(modifiedContent, schemaEdits);
-      }
-
-      return modifiedContent;
-    }
-
-    // Malformed, empty, or non-object JSONC — write a clean config
-    const config: Record<string, any> = {
-      $schema: 'https://opencode.ai/config.json',
-      [pluginsKey]: filtered,
-    };
-    return JSON.stringify(config, null, 2) + '\n';
-  }
-
-  // Plain JSON
-  let config: Record<string, any> = {};
-  if (existingContent) {
-    try {
-      config = JSON.parse(existingContent);
-    } catch {
-      // ignore malformed, overwrite
-    }
-  }
-
-  const pluginsKey = config.plugins === undefined ? 'plugin' : 'plugins';
-  const existing: string[] = config[pluginsKey] || [];
-  const filtered = existing.filter((p: string) => !p.includes(OPENCODE_PLUGIN_NAME));
-  filtered.push(OPENCODE_PLUGIN);
-  config[pluginsKey] = filtered;
-  config.$schema = config.$schema || 'https://opencode.ai/config.json';
-
-  return JSON.stringify(config, null, 2) + '\n';
-}
-
-function getOpencodeLabel(state: { global: boolean; project: boolean }): string {
-  if (state.project || state.global) return ' (already configured)';
-  return '';
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-async function getOpencodeState(
-  files: FileStore,
-  homeDir: string,
-  cwd: string,
-): Promise<{ global: boolean; project: boolean }> {
-  const projectJsonc = await readJsonMaybe(files, pathJoin(cwd, 'opencode.jsonc'));
-  const projectJson = await readJsonMaybe(files, pathJoin(cwd, 'opencode.json'));
-  const globalJsonc = await readJsonMaybe(
-    files,
-    pathJoin(homeDir, '.config', 'opencode', 'opencode.jsonc'),
-  );
-  const globalJson = await readJsonMaybe(
-    files,
-    pathJoin(homeDir, '.config', 'opencode', 'opencode.json'),
-  );
-
-  return {
-    global: (await hasPluginInConfig(globalJsonc)) || (await hasPluginInConfig(globalJson)),
-    project: (await hasPluginInConfig(projectJsonc)) || (await hasPluginInConfig(projectJson)),
-  };
-}
-
-function getPiLabel(state: { global: boolean; project: boolean }): string {
-  if (state.project || state.global) return ' (already configured)';
-  return '';
-}
-
-async function getPiState(
-  files: FileStore,
-  homeDir: string,
-  cwd: string,
-): Promise<{ global: boolean; project: boolean }> {
-  const projectSettings = await readJsonMaybe(files, pathJoin(cwd, '.pi', 'settings.json'));
-  const globalSettings = await readJsonMaybe(
-    files,
-    pathJoin(homeDir, '.pi', 'agent', 'settings.json'),
-  );
-
-  return {
-    global: await hasPiProviderInSettings(globalSettings),
-    project: await hasPiProviderInSettings(projectSettings),
-  };
-}
-
-async function hasPiProviderInSettings(settings: any): Promise<boolean> {
-  if (!settings) return false;
-  const packages = settings.packages || [];
-  return packages.some((p: any) => {
-    if (typeof p === 'string') return p.includes(PI_PROVIDER_NAME);
-    if (typeof p === 'object' && p.source) return p.source.includes(PI_PROVIDER_NAME);
-    return false;
-  });
-}
-
-async function hasPluginInConfig(config: any): Promise<boolean> {
-  if (!config) return false;
-  const plugins = config.plugin || config.plugins || [];
-  return plugins.some((p: string) => p.includes(OPENCODE_PLUGIN_NAME));
-}
-
-function pathJoin(...parts: string[]): string {
-  // Simple path join that avoids importing 'path' module
-  // This is good enough for cross-platform testing since tests control the path format
-  return parts.join('/');
-}
-
-async function readJsonMaybe(files: FileStore, filePath: string): Promise<any | null> {
-  const content = await files.readFile(filePath);
-  if (!content) return null;
-  try {
-    return JSON.parse(content);
-  } catch {
-    try {
-      return JSON.parse(stripJsoncComments(content));
-    } catch {
-      return null;
-    }
-  }
-}
-
-async function resolveOpencodeConfigPath(
-  files: FileStore,
-  homeDir: string,
-  cwd: string,
-  scope: 'global' | 'project',
-): Promise<string> {
-  if (scope === 'project') {
-    const jsoncPath = pathJoin(cwd, 'opencode.jsonc');
-    const jsonPath = pathJoin(cwd, 'opencode.json');
-    if (await files.exists(jsoncPath)) return jsoncPath;
-    if (await files.exists(jsonPath)) return jsonPath;
-    return jsonPath;
-  } else {
-    const globalDir = pathJoin(homeDir, '.config', 'opencode');
-    const jsoncPath = pathJoin(globalDir, 'opencode.jsonc');
-    const jsonPath = pathJoin(globalDir, 'opencode.json');
-    if (await files.exists(jsoncPath)) return jsoncPath;
-    if (await files.exists(jsonPath)) return jsonPath;
-    return jsonPath;
-  }
-}
-
-async function setupOpenCode(deps: {
-  commands: CommandRunner;
-  cwd: string;
-  files: FileStore;
-  homeDir: string;
-  prompter: Prompter;
-  scope: 'global' | 'project';
-}): Promise<void> {
-  const { commands, cwd, files, homeDir, prompter, scope } = deps;
-
-  const installed = await commands.checkInstalled('opencode');
-  if (!installed) {
-    throw new PrerequisiteError('opencode');
-  }
-
-  const configPath = await resolveOpencodeConfigPath(files, homeDir, cwd, scope);
-  const existingContent = await files.readFile(configPath);
-  const newContent = generateModifiedContent(existingContent, configPath);
-
-  if (existingContent && existingContent === newContent) {
-    return;
-  }
-
-  if (existingContent) {
-    prompter.note(`OpenCode config will be updated at:\n  ${configPath}`, 'Config update');
-  } else {
-    prompter.note(`OpenCode config will be created at:\n  ${configPath}`, 'Config update');
-  }
-
-  const shouldWrite = await prompter.confirm({
-    initialValue: true,
-    message: existingContent ? `Write these changes to ${configPath}?` : `Create ${configPath}?`,
-  });
-  if (!shouldWrite) throw new CancelledError();
-
-  const s = prompter.spinner();
-  s.start('Writing OpenCode configuration...');
-  await files.writeFile(configPath, newContent);
-  s.stop(`Wrote configuration to ${configPath}.`);
-}
-
-async function setupOpenCodeAgents(deps: {
-  cwd: string;
-  files: FileStore;
-  homeDir: string;
-  prompter: Prompter;
-  scope: 'global' | 'project';
-}): Promise<boolean> {
-  const { cwd, files, homeDir, prompter, scope } = deps;
-
-  const agents = getAllAgents().filter((a) => a.config.mode === 'primary');
-
-  if (agents.length === 0) {
-    return false;
-  }
-
-  const agentsDir =
-    scope === 'project'
-      ? pathJoin(cwd, '.opencode', 'agents')
-      : pathJoin(homeDir, '.config', 'opencode', 'agents');
-
-  prompter.note('Space to toggle, Enter to confirm.', 'Agent Setup');
-
-  const agentOptions = await Promise.all(
-    agents.map(async (agent) => {
-      const agentPath = pathJoin(agentsDir, `${agent.config.name}.md`);
-      const exists = await files.exists(agentPath);
-      return {
-        hint: exists ? 'already configured' : agent.config.description,
-        label: agent.config.name,
-        value: agent.config.name,
-      };
-    }),
-  );
-
-  const selectedAgents = await prompter.multiselect({
-    message: 'Select agents to set up:',
-    options: agentOptions,
-    required: false,
-  });
-
-  if (selectedAgents.length === 0) {
-    return false;
-  }
-
-  const newAgents: string[] = [];
-  const existingAgents: string[] = [];
-  await Promise.all(
-    selectedAgents.map(async (agentName) => {
-      const agentPath = pathJoin(agentsDir, `${agentName}.md`);
-      const exists = await files.exists(agentPath);
-      (exists ? existingAgents : newAgents).push(agentName);
-    }),
-  );
-
-  const summaryParts: string[] = [];
-  if (newAgents.length > 0) summaryParts.push(`New: ${newAgents.join(', ')}`);
-  if (existingAgents.length > 0) summaryParts.push(`Replaced: ${existingAgents.join(', ')}`);
-  if (summaryParts.length > 0) {
-    prompter.note(
-      `  Agent Setup Summary:\n${summaryParts.map((part) => `  ${part}`).join('\n')}`,
-      'Agent Setup',
-    );
-  }
-
-  const shouldWrite = await prompter.confirm({
-    initialValue: true,
-    message: 'Write agent configuration files?',
-  });
-
-  if (!shouldWrite) {
-    throw new CancelledError();
-  }
-
-  await files.mkdir(agentsDir);
-
-  const s = prompter.spinner();
-  s.start('Writing agent configurations...');
-
-  for (const agentName of selectedAgents) {
-    const agent = agents.find((a) => a.config.name === agentName);
-    if (!agent) continue;
-
-    const agentPath = pathJoin(agentsDir, `${agentName}.md`);
-    const content = toMarkdown(agent);
-    await files.writeFile(agentPath, content);
-  }
-
-  s.stop(`Wrote ${selectedAgents.length} agent(s) to ${agentsDir}`);
-  return true;
-}
-
-async function setupPi(deps: {
-  commands: CommandRunner;
-  cwd: string;
-  files: FileStore;
-  homeDir: string;
-  prompter: Prompter;
-  scope: 'global' | 'project';
-}): Promise<void> {
-  const { commands, cwd, files, homeDir, prompter, scope } = deps;
-  const s = prompter.spinner();
-
-  const installed = await commands.checkInstalled('pi');
-  if (!installed) {
-    throw new PrerequisiteError('pi');
-  }
-
-  const installArguments =
-    scope === 'project' ? ['install', '-l', PI_PROVIDER] : ['install', PI_PROVIDER];
-
-  s.start(`Installing Berget AI provider for Pi...`);
-  try {
-    await commands.run('pi', installArguments);
-    s.stop('Installed Pi provider.');
-  } catch {
-    s.stop('Pi provider installation failed. Please try again or install manually.');
-    throw new CommandFailedError(`pi ${installArguments.join(' ')}`, 1);
-  }
-
-  const settingsPath =
-    scope === 'project'
-      ? pathJoin(cwd, '.pi', 'settings.json')
-      : pathJoin(homeDir, '.pi', 'agent', 'settings.json');
-
-  const settings = (await readJsonMaybe(files, settingsPath)) || {};
-
-  if (settings.defaultProvider === 'berget') {
-    prompter.note(
-      'Berget AI is already set as your default provider.',
-      'Default provider already set',
-    );
-  } else {
-    if (settings.defaultProvider) {
-      const makeDefault = await prompter.confirm({
-        initialValue: false,
-        message: `Your default provider is ${settings.defaultProvider}. Switch to Berget AI instead?`,
-      });
-      if (makeDefault) {
-        settings.defaultProvider = 'berget';
-        await writeJsonFile(files, settingsPath, settings);
-        prompter.note('Berget AI is now your default provider.', 'Updated default provider');
-      }
-    } else {
-      settings.defaultProvider = 'berget';
-      await writeJsonFile(files, settingsPath, settings);
-      prompter.note('Berget AI is now your default provider.', 'Updated default provider');
-    }
-  }
-}
-
-async function setupPiAgent(deps: {
-  cwd: string;
-  files: FileStore;
-  homeDir: string;
-  prompter: Prompter;
-  scope: 'global' | 'project';
-}): Promise<boolean> {
-  const { cwd, files, homeDir, prompter, scope } = deps;
-
-  const agents = getAllAgents().filter((a) => a.config.mode === 'primary');
-
-  if (agents.length === 0) {
-    return false;
-  }
-
-  const systemPath =
-    scope === 'project'
-      ? pathJoin(cwd, '.pi', 'SYSTEM.md')
-      : pathJoin(homeDir, '.pi', 'agent', 'SYSTEM.md');
-
-  prompter.note('Pi uses a single system prompt.', 'Agent Setup');
-
-  const setupAgent = await prompter.confirm({
-    initialValue: false,
-    message: 'Set up an agent for Pi?',
-  });
-
-  if (!setupAgent) return false;
-
-  const selectedAgentName = await prompter.select({
-    message: 'Choose an agent:',
-    options: agents.map((agent) => ({
-      hint: agent.config.description,
-      label: agent.config.name,
-      value: agent.config.name,
-    })),
-  });
-
-  const agent = agents.find((a) => a.config.name === selectedAgentName);
-  if (!agent) return false;
-
-  const systemExists = await files.exists(systemPath);
-  const confirmMsg = systemExists
-    ? `SYSTEM.md already exists. Replace with ${agent.config.name}?`
-    : 'Create agent configuration?';
-
-  const shouldWrite = await prompter.confirm({
-    initialValue: true,
-    message: confirmMsg,
-  });
-
-  if (!shouldWrite) {
-    throw new CancelledError();
-  }
-
-  const s = prompter.spinner();
-  s.start('Writing agent configuration...');
-
-  const systemDir = scope === 'project' ? pathJoin(cwd, '.pi') : pathJoin(homeDir, '.pi', 'agent');
-  await files.mkdir(systemDir);
-  await files.writeFile(systemPath, toPiPrompt(agent));
-
-  s.stop(`Wrote agent configuration to ${systemPath}`);
-  return true;
-}
-
-function stripJsoncComments(content: string): string {
-  content = content.replaceAll(/\/\/.*$/gm, '');
-  content = content.replaceAll(/\/\*[\s\S]*?\*\//g, '');
-  return content;
-}
-
-async function writeJsonFile(
-  files: FileStore,
-  filePath: string,
-  data: Record<string, unknown>,
-): Promise<void> {
-  await files.writeFile(filePath, JSON.stringify(data, null, 2) + '\n');
 }

--- a/src/commands/code/opencode.ts
+++ b/src/commands/code/opencode.ts
@@ -1,0 +1,279 @@
+import { applyEdits, modify, parse } from 'jsonc-parser';
+import path from 'node:path';
+
+import type { CommandRunner } from './ports/command-runner.js';
+import type { FileStore } from './ports/file-store.js';
+import type { Prompter } from './ports/prompter.js';
+
+import { getAllAgents, toMarkdown } from '../../agents/index.js';
+import { CancelledError, PrerequisiteError } from './errors.js';
+import { readJsonMaybe } from './utils.js';
+
+const OPENCODE_PLUGIN = '@bergetai/opencode-auth@1.0.22';
+const OPENCODE_PLUGIN_NAME = '@bergetai/opencode-auth';
+
+export interface InitOpenCodeDeps {
+  commands: CommandRunner;
+  cwd: string;
+  files: FileStore;
+  homeDir: string;
+  prompter: Prompter;
+  scope: 'global' | 'project';
+}
+
+export function getOpencodeLabel(state: { global: boolean; project: boolean }): string {
+  if (state.project || state.global) return ' (already configured)';
+  return '';
+}
+
+export async function getOpencodeState(
+  files: FileStore,
+  homeDir: string,
+  cwd: string,
+): Promise<{ global: boolean; project: boolean }> {
+  const projectJsonc = await readJsonMaybe(files, path.join(cwd, 'opencode.jsonc'));
+  const projectJson = await readJsonMaybe(files, path.join(cwd, 'opencode.json'));
+  const globalJsonc = await readJsonMaybe(
+    files,
+    path.join(homeDir, '.config', 'opencode', 'opencode.jsonc'),
+  );
+  const globalJson = await readJsonMaybe(
+    files,
+    path.join(homeDir, '.config', 'opencode', 'opencode.json'),
+  );
+
+  return {
+    global: hasPluginInConfig(globalJsonc) || hasPluginInConfig(globalJson),
+    project: hasPluginInConfig(projectJsonc) || hasPluginInConfig(projectJson),
+  };
+}
+
+/* ─── State helpers ─────────────────────────────────────────────────────── */
+
+export async function initOpenCode(deps: InitOpenCodeDeps): Promise<void> {
+  const { commands, cwd, files, homeDir, prompter, scope } = deps;
+
+  const installed = await commands.checkInstalled('opencode');
+  if (!installed) {
+    throw new PrerequisiteError('opencode');
+  }
+
+  const configPath = await resolveOpencodeConfigPath(files, homeDir, cwd, scope);
+  const existingContent = await files.readFile(configPath);
+  const newContent = generateModifiedContent(existingContent, configPath);
+
+  if (existingContent && existingContent === newContent) {
+    return;
+  }
+
+  if (existingContent) {
+    prompter.note(`OpenCode config will be updated at:\n  ${configPath}`, 'Config update');
+  } else {
+    prompter.note(`OpenCode config will be created at:\n  ${configPath}`, 'Config update');
+  }
+
+  const shouldWrite = await prompter.confirm({
+    initialValue: true,
+    message: existingContent ? `Write these changes to ${configPath}?` : `Create ${configPath}?`,
+  });
+  if (!shouldWrite) throw new CancelledError();
+
+  const s = prompter.spinner();
+  s.start('Writing OpenCode configuration...');
+  await files.writeFile(configPath, newContent);
+  s.stop(`Wrote configuration to ${configPath}.`);
+}
+
+export async function initOpenCodeAgents(deps: {
+  cwd: string;
+  files: FileStore;
+  homeDir: string;
+  prompter: Prompter;
+  scope: 'global' | 'project';
+}): Promise<boolean> {
+  const { cwd, files, homeDir, prompter, scope } = deps;
+
+  const agents = getAllAgents().filter((a) => a.config.mode === 'primary');
+
+  if (agents.length === 0) {
+    return false;
+  }
+
+  const agentsDir =
+    scope === 'project'
+      ? path.join(cwd, '.opencode', 'agents')
+      : path.join(homeDir, '.config', 'opencode', 'agents');
+
+  prompter.note('Space to toggle, Enter to confirm.', 'Agent Setup');
+
+  const agentOptions = await Promise.all(
+    agents.map(async (agent) => {
+      const agentPath = path.join(agentsDir, `${agent.config.name}.md`);
+      const exists = await files.exists(agentPath);
+      return {
+        hint: exists ? 'already configured' : agent.config.description,
+        label: agent.config.name,
+        value: agent.config.name,
+      };
+    }),
+  );
+
+  const selectedAgents = await prompter.multiselect({
+    message: 'Select agents to set up:',
+    options: agentOptions,
+    required: false,
+  });
+
+  if (selectedAgents.length === 0) {
+    return false;
+  }
+
+  const newAgents: string[] = [];
+  const existingAgents: string[] = [];
+  await Promise.all(
+    selectedAgents.map(async (agentName: string) => {
+      const agentPath = path.join(agentsDir, `${agentName}.md`);
+      const exists = await files.exists(agentPath);
+      (exists ? existingAgents : newAgents).push(agentName);
+    }),
+  );
+
+  const summaryParts: string[] = [];
+  if (newAgents.length > 0) summaryParts.push(`New: ${newAgents.join(', ')}`);
+  if (existingAgents.length > 0) summaryParts.push(`Replaced: ${existingAgents.join(', ')}`);
+  if (summaryParts.length > 0) {
+    prompter.note(
+      `  Agent Setup Summary:\n${summaryParts.map((part) => `  ${part}`).join('\n')}`,
+      'Agent Setup',
+    );
+  }
+
+  const shouldWrite = await prompter.confirm({
+    initialValue: true,
+    message: 'Write agent configuration files?',
+  });
+
+  if (!shouldWrite) {
+    throw new CancelledError();
+  }
+
+  await files.mkdir(agentsDir);
+
+  const s = prompter.spinner();
+  s.start('Writing agent configurations...');
+
+  for (const agentName of selectedAgents) {
+    const agent = agents.find((a) => a.config.name === agentName);
+    if (!agent) continue;
+
+    const agentPath = path.join(agentsDir, `${agentName}.md`);
+    const content = toMarkdown(agent);
+    await files.writeFile(agentPath, content);
+  }
+
+  s.stop(`Wrote ${selectedAgents.length} agent(s) to ${agentsDir}`);
+  return true;
+}
+
+function generateModifiedContent(existingContent: null | string, configPath: string): string {
+  if (configPath.endsWith('.jsonc')) {
+    const content = existingContent || '{}';
+    const parseErrors: any[] = [];
+    const parsed = parse(content, parseErrors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+
+    let jsConfig: Record<string, unknown> = {};
+    const canModifyText =
+      parsed !== undefined &&
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed);
+
+    if (canModifyText) {
+      jsConfig = parsed as Record<string, unknown>;
+    }
+
+    const pluginsKey = jsConfig.plugins === undefined ? 'plugin' : 'plugins';
+    const existingPlugins: string[] = (jsConfig[pluginsKey] as string[]) || [];
+    const filtered = existingPlugins.filter((p: string) => !p.includes(OPENCODE_PLUGIN_NAME));
+    filtered.push(OPENCODE_PLUGIN);
+
+    if (canModifyText) {
+      let modifiedContent = content;
+      const pluginEdits = modify(modifiedContent, [pluginsKey], filtered, {
+        formattingOptions: { insertSpaces: true, tabSize: 2 },
+      });
+      modifiedContent = applyEdits(modifiedContent, pluginEdits);
+
+      if (!jsConfig.$schema) {
+        const schemaEdits = modify(
+          modifiedContent,
+          ['$schema'],
+          'https://opencode.ai/config.json',
+          {
+            formattingOptions: { insertSpaces: true, tabSize: 2 },
+          },
+        );
+        modifiedContent = applyEdits(modifiedContent, schemaEdits);
+      }
+
+      return modifiedContent;
+    }
+
+    const config: Record<string, unknown> = {
+      $schema: 'https://opencode.ai/config.json',
+      [pluginsKey]: filtered,
+    };
+    return JSON.stringify(config, null, 2) + '\n';
+  }
+
+  let config: Record<string, unknown> = {};
+  if (existingContent) {
+    try {
+      config = JSON.parse(existingContent);
+    } catch {
+      // ignore malformed, overwrite
+    }
+  }
+
+  const pluginsKey = config.plugins === undefined ? 'plugin' : 'plugins';
+  const existingPlugins: string[] = (config[pluginsKey] as string[]) || [];
+  const filtered = existingPlugins.filter((p: string) => !p.includes(OPENCODE_PLUGIN_NAME));
+  filtered.push(OPENCODE_PLUGIN);
+  config[pluginsKey] = filtered;
+  config.$schema = config.$schema || 'https://opencode.ai/config.json';
+
+  return JSON.stringify(config, null, 2) + '\n';
+}
+
+function hasPluginInConfig(config: unknown): boolean {
+  if (!config || typeof config !== 'object') return false;
+  const plugins =
+    (config as Record<string, unknown>).plugin || (config as Record<string, unknown>).plugins;
+  if (!Array.isArray(plugins)) return false;
+  return plugins.some((p: unknown) => typeof p === 'string' && p.includes(OPENCODE_PLUGIN_NAME));
+}
+
+async function resolveOpencodeConfigPath(
+  files: FileStore,
+  homeDir: string,
+  cwd: string,
+  scope: 'global' | 'project',
+): Promise<string> {
+  if (scope === 'project') {
+    const jsoncPath = path.join(cwd, 'opencode.jsonc');
+    const jsonPath = path.join(cwd, 'opencode.json');
+    if (await files.exists(jsoncPath)) return jsoncPath;
+    if (await files.exists(jsonPath)) return jsonPath;
+    return jsonPath;
+  }
+
+  const globalDir = path.join(homeDir, '.config', 'opencode');
+  const jsoncPath = path.join(globalDir, 'opencode.jsonc');
+  const jsonPath = path.join(globalDir, 'opencode.json');
+  if (await files.exists(jsoncPath)) return jsoncPath;
+  if (await files.exists(jsonPath)) return jsonPath;
+  return jsonPath;
+}

--- a/src/commands/code/pi.ts
+++ b/src/commands/code/pi.ts
@@ -1,0 +1,183 @@
+import path from 'node:path';
+
+import type { CommandRunner } from './ports/command-runner.js';
+import type { FileStore } from './ports/file-store.js';
+import type { Prompter } from './ports/prompter.js';
+
+import { getAllAgents, toPiPrompt } from '../../agents/index.js';
+import { CancelledError, CommandFailedError, PrerequisiteError } from './errors.js';
+import { readJsonMaybe, writeJsonFile } from './utils.js';
+
+const PI_PROVIDER = 'npm:@bergetai/pi-provider';
+const PI_PROVIDER_NAME = '@bergetai/pi-provider';
+
+export interface InitPiDeps {
+  commands: CommandRunner;
+  cwd: string;
+  files: FileStore;
+  homeDir: string;
+  prompter: Prompter;
+  scope: 'global' | 'project';
+}
+
+export function getPiLabel(state: { global: boolean; project: boolean }): string {
+  if (state.project || state.global) return ' (already configured)';
+  return '';
+}
+
+export async function getPiState(
+  files: FileStore,
+  homeDir: string,
+  cwd: string,
+): Promise<{ global: boolean; project: boolean }> {
+  const projectSettings = await readJsonMaybe(files, path.join(cwd, '.pi', 'settings.json'));
+  const globalSettings = await readJsonMaybe(
+    files,
+    path.join(homeDir, '.pi', 'agent', 'settings.json'),
+  );
+
+  return {
+    global: hasPiProviderInSettings(globalSettings),
+    project: hasPiProviderInSettings(projectSettings),
+  };
+}
+
+/* ─── State helpers ─────────────────────────────────────────────────────── */
+
+export async function initPi(deps: InitPiDeps): Promise<void> {
+  const { commands, cwd, files, homeDir, prompter, scope } = deps;
+  const s = prompter.spinner();
+
+  const installed = await commands.checkInstalled('pi');
+  if (!installed) {
+    throw new PrerequisiteError('pi');
+  }
+
+  const installArguments =
+    scope === 'project' ? ['install', '-l', PI_PROVIDER] : ['install', PI_PROVIDER];
+
+  s.start('Installing Berget AI provider for Pi...');
+  try {
+    await commands.run('pi', installArguments);
+    s.stop('Installed Pi provider.');
+  } catch {
+    s.stop('Pi provider installation failed. Please try again or install manually.');
+    throw new CommandFailedError(`pi ${installArguments.join(' ')}`, 1);
+  }
+
+  const settingsPath =
+    scope === 'project'
+      ? path.join(cwd, '.pi', 'settings.json')
+      : path.join(homeDir, '.pi', 'agent', 'settings.json');
+
+  const raw = await readJsonMaybe(files, settingsPath);
+  const settings: Record<string, unknown> =
+    typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : {};
+
+  if (settings.defaultProvider === 'berget') {
+    prompter.note(
+      'Berget AI is already set as your default provider.',
+      'Default provider already set',
+    );
+    return;
+  }
+
+  if (settings.defaultProvider) {
+    const makeDefault = await prompter.confirm({
+      initialValue: false,
+      message: `Your default provider is ${settings.defaultProvider}. Switch to Berget AI instead?`,
+    });
+    if (makeDefault) {
+      settings.defaultProvider = 'berget';
+      await writeJsonFile(files, settingsPath, settings);
+      prompter.note('Berget AI is now your default provider.', 'Updated default provider');
+    }
+  } else {
+    settings.defaultProvider = 'berget';
+    await writeJsonFile(files, settingsPath, settings);
+    prompter.note('Berget AI is now your default provider.', 'Updated default provider');
+  }
+}
+
+export async function initPiAgent(deps: {
+  cwd: string;
+  files: FileStore;
+  homeDir: string;
+  prompter: Prompter;
+  scope: 'global' | 'project';
+}): Promise<boolean> {
+  const { cwd, files, homeDir, prompter, scope } = deps;
+
+  const agents = getAllAgents().filter((a) => a.config.mode === 'primary');
+
+  if (agents.length === 0) {
+    return false;
+  }
+
+  const systemPath =
+    scope === 'project'
+      ? path.join(cwd, '.pi', 'SYSTEM.md')
+      : path.join(homeDir, '.pi', 'agent', 'SYSTEM.md');
+
+  prompter.note('Pi uses a single system prompt.', 'Agent Setup');
+
+  const shouldInitAgent = await prompter.confirm({
+    initialValue: false,
+    message: 'Set up an agent for Pi?',
+  });
+
+  if (!shouldInitAgent) return false;
+
+  const selectedAgentName = await prompter.select({
+    message: 'Choose an agent:',
+    options: agents.map((agent) => ({
+      hint: agent.config.description,
+      label: agent.config.name,
+      value: agent.config.name,
+    })),
+  });
+
+  const agent = agents.find((a) => a.config.name === selectedAgentName);
+  if (!agent) return false;
+
+  const systemExists = await files.exists(systemPath);
+  const confirmMsg = systemExists
+    ? `SYSTEM.md already exists. Replace with ${agent.config.name}?`
+    : 'Create agent configuration?';
+
+  const shouldWrite = await prompter.confirm({
+    initialValue: true,
+    message: confirmMsg,
+  });
+
+  if (!shouldWrite) {
+    throw new CancelledError();
+  }
+
+  const s = prompter.spinner();
+  s.start('Writing agent configuration...');
+
+  const systemDir =
+    scope === 'project' ? path.join(cwd, '.pi') : path.join(homeDir, '.pi', 'agent');
+  await files.mkdir(systemDir);
+  await files.writeFile(systemPath, toPiPrompt(agent));
+
+  s.stop(`Wrote agent configuration to ${systemPath}`);
+  return true;
+}
+
+function hasPiProviderInSettings(settings: unknown): boolean {
+  if (!settings || typeof settings !== 'object') return false;
+  const packages = (settings as Record<string, unknown>).packages;
+  if (!Array.isArray(packages)) return false;
+  return packages.some((p: unknown) => {
+    if (typeof p === 'string') return p.includes(PI_PROVIDER_NAME);
+    if (typeof p === 'object' && p !== null) {
+      const source = (p as Record<string, unknown>).source;
+      return typeof source === 'string' && source.includes(PI_PROVIDER_NAME);
+    }
+    return false;
+  });
+}

--- a/src/commands/code/utils.ts
+++ b/src/commands/code/utils.ts
@@ -1,0 +1,29 @@
+import type { FileStore } from './ports/file-store.js';
+
+export async function readJsonMaybe(files: FileStore, filePath: string): Promise<null | unknown> {
+  const content = await files.readFile(filePath);
+  if (!content) return null;
+  try {
+    return JSON.parse(content);
+  } catch {
+    try {
+      return JSON.parse(stripJsoncComments(content));
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function stripJsoncComments(content: string): string {
+  content = content.replaceAll(/\/\/.*$/gm, '');
+  content = content.replaceAll(/\/\*[\s\S]*?\*\//g, '');
+  return content;
+}
+
+export async function writeJsonFile(
+  files: FileStore,
+  filePath: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await files.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}


### PR DESCRIPTION
Split the monolithic `init.ts` (617 lines) into focused, single-responsibility modules:

**New files:**
- `src/commands/code/opencode.ts` — OpenCode config + agent setup
- `src/commands/code/pi.ts` — Pi provider install + agent setup  
- `src/commands/code/utils.ts` — Shared JSON helpers

**Changes to `init.ts`:**
- Reduced from ~617 lines to ~158 lines
- Now a pure orchestrator: selects tool/scope → runs auth → delegates to module
- Renamed internal `setup*` functions to `init*` for consistency with the command name
- Replaced hand-rolled `pathJoin` with `node:path.join`

**Verification:**
- `tsc --noEmit` — clean
- 165 tests pass across 16 test files
- Zero test modifications required