### PR TITLE
fix(code): display API key creation errors gracefully and exit immediately

### DIFF
--- a/src/commands/code/__tests__/auth-sync.test.ts
+++ b/src/commands/code/__tests__/auth-sync.test.ts
@@ -10,6 +10,7 @@ import {
   syncApiKeyToTool,
   syncOAuthToTool,
 } from '../auth-sync.js';
+import { FatalError } from '../errors.js';
 import { FakeApiKeyService } from './fake-api-key-service.js';
 import { FakeAuthService } from './fake-auth-service.js';
 import { FakeFileStore } from './fake-file-store.js';
@@ -414,6 +415,54 @@ describe('configureAuth', () => {
     const parsed = JSON.parse(written.get(HOME + '/.local/share/opencode/auth.json')!);
     expect(parsed.berget.type).toBe('api');
     expect(parsed.berget.key).toBe('sk_ber_test');
+  });
+
+  it('Case B variant failure: login success + seat → chooses api_key + creation fails', async () => {
+    const files = new FakeFileStore();
+    const jwt = makeJwt({
+      exp: 9_999_999_999_999,
+      realm_access: { roles: ['berget_code_seat'] },
+    });
+    files.seed(
+      HOME + '/.berget/auth.json',
+      JSON.stringify({
+        access_token: jwt,
+        expires_at: 9_999_999_999_999,
+        refresh_token: 'ref',
+      }),
+    );
+
+    const prompter = new FakePrompter([select('api_key')]);
+    const failingApiKeyService = new FakeApiKeyService(
+      'sk_ber_test',
+      true,
+      'Before you can create API keys, you need to finish setting up your account.',
+    );
+
+    const deps = makeAuthDeps({ apiKeyService: failingApiKeyService, files, prompter });
+
+    await expect(configureAuth(deps, 'opencode')).rejects.toThrow(FatalError);
+    expect(files.getWrittenFiles().has(HOME + '/.local/share/opencode/auth.json')).toBe(false);
+  });
+
+  it('Case C failure: login success + no seat → confirms api key + creation fails', async () => {
+    const files = new FakeFileStore();
+    const prompter = new FakePrompter([confirm(true)]);
+
+    const failingApiKeyService = new FakeApiKeyService(
+      'sk_ber_test',
+      true,
+      'Before you can create API keys, you need to finish setting up your account.',
+    );
+    const deps = makeAuthDeps({
+      apiKeyService: failingApiKeyService,
+      authService: new FakeAuthService(true, false),
+      files,
+      prompter,
+    });
+
+    await expect(configureAuth(deps, 'opencode')).rejects.toThrow(FatalError);
+    expect(files.getWrittenFiles().has(HOME + '/.local/share/opencode/auth.json')).toBe(false);
   });
 
   it('Case D: login success + no seat → declines api key', async () => {

--- a/src/commands/code/__tests__/fake-api-key-service.ts
+++ b/src/commands/code/__tests__/fake-api-key-service.ts
@@ -1,13 +1,20 @@
 import type { ApiKeyServicePort } from '../ports/auth-services.js';
 
 export class FakeApiKeyService implements ApiKeyServicePort {
+  private readonly _errorMessage: string;
   private readonly _key: string;
+  private readonly _shouldFail: boolean;
 
-  constructor(key: string) {
+  constructor(key: string, shouldFail = false, errorMessage = 'API key creation failed') {
     this._key = key;
+    this._shouldFail = shouldFail;
+    this._errorMessage = errorMessage;
   }
 
   async create(_options: { description?: string; name: string }): Promise<{ key: string }> {
+    if (this._shouldFail) {
+      throw new Error(this._errorMessage);
+    }
     return { key: this._key };
   }
 }

--- a/src/commands/code/__tests__/fake-prompter.ts
+++ b/src/commands/code/__tests__/fake-prompter.ts
@@ -48,6 +48,9 @@ export class FakePrompter implements Prompter {
       throw new Error(`Script not exhausted: ${this._script.length - this._cursor} entries left`);
     }
   }
+  cancel(message: string): void {
+    this._calls.push({ args: { message }, method: 'cancel' });
+  }
   async confirm(options: { message: string }): Promise<boolean> {
     this._calls.push({ args: options, method: 'confirm' });
     const entry = this._script[this._cursor++];

--- a/src/commands/code/adapters/clack-prompter.ts
+++ b/src/commands/code/adapters/clack-prompter.ts
@@ -10,6 +10,9 @@ const unwrap = <T>(v: symbol | T): T => {
 };
 
 export class ClackPrompter implements Prompter {
+  cancel(message: string): void {
+    p.cancel(message);
+  }
   async confirm(options: { initialValue?: boolean; message: string }): Promise<boolean> {
     return unwrap(await p.confirm(options));
   }

--- a/src/commands/code/auth-sync.ts
+++ b/src/commands/code/auth-sync.ts
@@ -8,6 +8,7 @@ import {
   hasBergetCodeSeat,
   isTokenExpired,
 } from '../../auth/jwt.js';
+import { FatalError } from './errors.js';
 
 export interface AuthDeps {
   apiKeyService: ApiKeyServicePort;
@@ -144,13 +145,12 @@ export async function configureAuth(deps: AuthDeps, tool: 'opencode' | 'pi'): Pr
       await syncApiKeyToTool(files, homeDir, tool, key);
       s.stop('API key created and saved.');
       return { authenticated: true };
-    } catch {
+    } catch (error: any) {
       s.stop('API key creation failed.');
-      prompter.note(
-        'Could not create API key. Please create one manually with `berget api-keys create`.',
-        'Error',
+      throw new FatalError(
+        error?.message ||
+          'Could not create API key. Please create one manually with `berget api-keys create`.',
       );
-      return { authenticated: false };
     }
   }
 
@@ -171,13 +171,12 @@ export async function configureAuth(deps: AuthDeps, tool: 'opencode' | 'pi'): Pr
       await syncApiKeyToTool(files, homeDir, tool, key);
       s.stop('API key created and saved.');
       return { authenticated: true };
-    } catch {
+    } catch (error: any) {
       s.stop('API key creation failed.');
-      prompter.note(
-        'Could not create API key. Please create one manually with `berget api-keys create`.',
-        'Error',
+      throw new FatalError(
+        error?.message ||
+          'Could not create API key. Please create one manually with `berget api-keys create`.',
       );
-      return { authenticated: false };
     }
   }
 

--- a/src/commands/code/errors.ts
+++ b/src/commands/code/errors.ts
@@ -15,6 +15,13 @@ export class CommandFailedError extends Error {
   }
 }
 
+export class FatalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FatalError';
+  }
+}
+
 export class PrerequisiteError extends Error {
   constructor(public readonly binary: string) {
     super(`Required binary not found: ${binary}`);

--- a/src/commands/code/init.ts
+++ b/src/commands/code/init.ts
@@ -12,7 +12,7 @@ import { ClackPrompter } from './adapters/clack-prompter.js';
 import { FsFileStore } from './adapters/fs-file-store.js';
 import { SpawnCommandRunner } from './adapters/spawn-command-runner.js';
 import { configureAuth } from './auth-sync.js';
-import { CancelledError, CommandFailedError, PrerequisiteError } from './errors.js';
+import { CancelledError, CommandFailedError, FatalError, PrerequisiteError } from './errors.js';
 import {
   getOpencodeLabel,
   getOpencodeState,
@@ -144,6 +144,10 @@ export async function runInitCommand(): Promise<void> {
   } catch (error) {
     if (error instanceof CancelledError) {
       process.exit(130);
+    }
+    if (error instanceof FatalError) {
+      console.error(error.message);
+      process.exit(1);
     }
     if (error instanceof PrerequisiteError) {
       console.error(`Missing required binary: ${error.binary}`);

--- a/src/commands/code/ports/prompter.ts
+++ b/src/commands/code/ports/prompter.ts
@@ -1,4 +1,5 @@
 export interface Prompter {
+  cancel(message: string): void;
   confirm(options: { initialValue?: boolean; message: string }): Promise<boolean>;
   intro(message: string): void;
   multiselect<T>(options: {

--- a/src/services/api-key-service.ts
+++ b/src/services/api-key-service.ts
@@ -97,7 +97,7 @@ export class ApiKeyService {
 
           if (errorObject.error?.code === 'USER_NOT_FOUND') {
             throw new Error(
-              'Your account is still being set up. Please wait a moment and try again.\n\nIf this issue persists, please contact support at support@berget.ai',
+              'Before you can create API keys, you need to finish setting up your account.\n\nCheck your inbox for a verification email from Berget AI and complete the account setup.',
             );
           }
 
@@ -129,8 +129,6 @@ export class ApiKeyService {
 
       return data;
     } catch (error) {
-      console.error('Failed to create API key:', error);
-
       // Add additional context for common issues
       if (error instanceof Error) {
         if (error.message.includes('ECONNREFUSED')) {


### PR DESCRIPTION
When API key creation fails during `berget code init`, the raw stack trace was printed inline while the spinner was active, producing ugly and confusing output. The wizard would then continue with provider and agent setup even though authentication had failed.

**Changes:**

- **Add `FatalError`** class to signal unrecoverable wizard failures that should abort the flow
- **Remove `console.error`** from `api-key-service.create()` that leaked raw stack traces into the spinner line
- **Throw `FatalError`** from `auth-sync.ts` when API key creation fails, instead of swallowing the error and returning `{authenticated:false}`
- **Catch `FatalError`** in `init.ts`, show the clean message in a boxed note, and exit with code 1 before any provider/agent setup runs
- **Improve `USER_NOT_FOUND` error message** from "Your account is still being set up" to "Before you can create API keys, you need to finish setting up your account. Check your inbox for a verification email from Berget AI and complete the account setup."
- **Add tests** for the two API key creation failure paths (has seat + chooses API key, and no seat + confirms API key)