### PR TITLE
fix(auth): bind OAuth callback server to 127.0.0.1

### DIFF
--- a/src/auth/__tests__/pkce-flow.test.ts
+++ b/src/auth/__tests__/pkce-flow.test.ts
@@ -56,7 +56,7 @@ function createMockServer(options: { eaddrinuse?: boolean } = {}): any {
         }
       }
     },
-    listen: vi.fn((port: number) => {
+    listen: vi.fn((port: number, _host?: string) => {
       listenCallCount++;
       if (options.eaddrinuse && listenCallCount === 1 && port === 8787) {
         setTimeout(() => {
@@ -154,7 +154,7 @@ describe('startPkceFlow', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(mockServer.listen).toHaveBeenCalledWith(8787);
+    expect(mockServer.listen).toHaveBeenCalledWith(8787, '127.0.0.1');
 
     // Trigger the callback request
     const req = {
@@ -202,8 +202,8 @@ describe('startPkceFlow', () => {
     const result = await flowPromise;
 
     expect(result.success).toBe(true);
-    expect(mockServer.listen).toHaveBeenCalledWith(8787);
-    expect(mockServer.listen).toHaveBeenCalledWith(0);
+    expect(mockServer.listen).toHaveBeenCalledWith(8787, '127.0.0.1');
+    expect(mockServer.listen).toHaveBeenCalledWith(0, '127.0.0.1');
   });
 
   it('returns error when state mismatch', async () => {

--- a/src/auth/oauth/pkce-flow.ts
+++ b/src/auth/oauth/pkce-flow.ts
@@ -43,7 +43,7 @@ export async function startPkceFlow(options: PkceFlowOptions): Promise<BrowserAu
 
   try {
     const { port, server } = await startCallbackServer(createServerFactory);
-    const redirectUri = `http://localhost:${port}/callback`;
+    const redirectUri = `http://127.0.0.1:${port}/callback`;
 
     if (debug) {
       console.log(`Callback server listening on port ${port}`);
@@ -90,7 +90,7 @@ export async function startPkceFlow(options: PkceFlowOptions): Promise<BrowserAu
       };
 
       server.on('request', (request, res) => {
-        const requestUrl = new URL(request.url || '', `http://localhost:${port}`);
+        const requestUrl = new URL(request.url || '', `http://127.0.0.1:${port}`);
 
         if (requestUrl.pathname !== '/callback') {
           res.writeHead(404, { Connection: 'close' });
@@ -232,7 +232,7 @@ function startCallbackServer(
         }
       });
 
-      server.listen(port);
+      server.listen(port, '127.0.0.1');
     }
 
     attemptListen(FALLBACK_CALLBACK_PORT);

--- a/tests/auth/oauth/pkce-flow.test.ts
+++ b/tests/auth/oauth/pkce-flow.test.ts
@@ -1,0 +1,108 @@
+import * as http from 'node:http';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('openid-client', async () => ({
+  authorizationCodeGrant: vi.fn(() =>
+    Promise.resolve({
+      access_token: 'mock-access-token',
+      expires_in: 3600,
+      refresh_token: 'mock-refresh-token',
+    }),
+  ),
+  buildAuthorizationUrl: vi.fn((_config, params) => {
+    const url = new URL('https://mock-idp/authorize');
+    for (const [key, value] of Object.entries(params || {})) {
+      url.searchParams.set(key, String(value));
+    }
+    return url;
+  }),
+  calculatePKCECodeChallenge: vi.fn(() => Promise.resolve('mock-challenge')),
+  randomPKCECodeVerifier: vi.fn(() => 'mock-verifier'),
+  ResponseBodyError: class ResponseBodyError extends Error {
+    error: string;
+    response: any;
+    status: number;
+    constructor(message: string, error: string, status: number, response: any) {
+      super(message);
+      this.error = error;
+      this.status = status;
+      this.response = response;
+    }
+  },
+}));
+
+vi.mock('open', () => ({
+  default: vi.fn(),
+}));
+
+import open from 'open';
+
+import { startPkceFlow } from '../../../src/auth/oauth/pkce-flow.js';
+
+describe('PKCE Flow - Issue 1: Callback Server Binding', () => {
+  it('should bind callback server to 127.0.0.1 and use 127.0.0.1 in redirect URI', async () => {
+    let capturedAddress: undefined | { address: string; family: string; port: number };
+    let capturedAuthUrl: string | undefined;
+
+    const createServerSpy = vi.fn((...args: any[]) => {
+      const server = http.createServer(...args);
+
+      // Hook the 'listening' event to capture bind address before server is potentially closed
+      const originalOn = server.on.bind(server);
+      server.on = function (event: string, listener: any) {
+        if (event === 'listening') {
+          const wrapped = () => {
+            const addr = server.address();
+            if (addr && typeof addr === 'object') {
+              capturedAddress = addr as { address: string; family: string; port: number };
+            }
+            listener();
+          };
+          return originalOn(event, wrapped);
+        }
+        return originalOn(event, listener);
+      } as any;
+
+      return server;
+    });
+
+    vi.mocked(open).mockImplementation(async (url: string) => {
+      capturedAuthUrl = url;
+
+      const authUrl = new URL(url);
+      const state = authUrl.searchParams.get('state');
+      const redirectUri = authUrl.searchParams.get('redirect_uri');
+
+      expect(redirectUri).toBeTruthy();
+      const redirectUrl = new URL(redirectUri!);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      return new Promise<void>((resolve, reject) => {
+        const req = http.get(
+          `http://${redirectUrl.hostname}:${redirectUrl.port}/callback?code=test-auth-code&state=${state}`,
+          (res) => {
+            res.resume();
+            resolve();
+          },
+        );
+        req.on('error', reject);
+      });
+    });
+
+    const result = await startPkceFlow({
+      config: {} as any,
+      createServer: createServerSpy,
+    });
+
+    expect(capturedAddress).toBeDefined();
+    expect(capturedAddress?.address).toBe('127.0.0.1');
+    expect(capturedAddress?.family).toBe('IPv4');
+    expect(capturedAuthUrl).toBeDefined();
+    const authUrl = new URL(capturedAuthUrl!);
+    const redirectUri = authUrl.searchParams.get('redirect_uri');
+    expect(redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes TODO.md issue #1.

**Problem:** The local callback server Implicitly bound to 0.0.0.0, making the OAuth callback reachable from any host on the same network.

**Changes:**
- Bind the server explicitly to 127.0.0.1
- Update redirectUri to use 127.0.0.1 instead of localhost
- Update request URL construction to use 127.0.0.1 base
- Add integration test verifying the server address and redirect URI
- Update existing tests to expect the new listen() signature