### PR TITLE
fix(auth): escape HTML in OAuth error callback pages

### DIFF
--- a/src/auth/oauth/callback-pages.ts
+++ b/src/auth/oauth/callback-pages.ts
@@ -4,6 +4,8 @@
  */
 
 export function getErrorPage(title: string, message: string): string {
+  const safeTitle = escapeHtml(title);
+  const safeMessage = escapeHtml(message);
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -51,8 +53,8 @@ export function getErrorPage(title: string, message: string): string {
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
       </div>
-      <h1>${title}</h1>
-      <p>${message}</p>
+      <h1>${safeTitle}</h1>
+      <p>${safeMessage}</p>
       <div class="brand">BERGET</div>
     </div>
   </body>
@@ -112,4 +114,16 @@ export function getSuccessPage(): string {
     </div>
   </body>
 </html>`;
+}
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
 }

--- a/tests/auth/oauth/callback-pages.test.ts
+++ b/tests/auth/oauth/callback-pages.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { getErrorPage, getSuccessPage } from '../../../src/auth/oauth/callback-pages.js';
+
+describe('getErrorPage', () => {
+  it('renders the provided title and message', () => {
+    const html = getErrorPage('Auth Failed', 'Invalid credentials');
+    expect(html).toContain('<h1>Auth Failed</h1>');
+    expect(html).toContain('<p>Invalid credentials</p>');
+  });
+
+  it('escapes HTML special characters in the title', () => {
+    const malicious = '<script>alert("xss")</script>';
+    const html = getErrorPage(malicious, 'message');
+
+    expect(html).not.toContain(malicious);
+    expect(html).toContain('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+    expect(html).toContain('<h1>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</h1>');
+  });
+
+  it('escapes HTML special characters in the message', () => {
+    const malicious = '<img src=x onerror=alert(1)>';
+    const html = getErrorPage('title', malicious);
+
+    expect(html).not.toContain(malicious);
+    expect(html).toContain('<p>&lt;img src=x onerror=alert(1)&gt;</p>');
+  });
+
+  it('escapes ampersands', () => {
+    const html = getErrorPage('A & B', 'C & D');
+    expect(html).toContain('<h1>A &amp; B</h1>');
+    expect(html).toContain('<p>C &amp; D</p>');
+  });
+
+  it('escapes single quotes', () => {
+    const html = getErrorPage("It's broken", "Don't panic");
+    expect(html).toContain('<h1>It&#x27;s broken</h1>');
+    expect(html).toContain('<p>Don&#x27;t panic</p>');
+  });
+});
+
+describe('getSuccessPage', () => {
+  it('renders the success page', () => {
+    const html = getSuccessPage();
+    expect(html).toContain('Authentication Successful');
+    expect(html).toContain('You can close this window');
+  });
+});


### PR DESCRIPTION
Fixes TODO.md issue #2.

**Problem:** getErrorPage unsafely interpolated title and message into HTML without escaping, allowing reflected XSS.

**Changes:**
- Add escapeHtml() utility escaping &, <, >, "', "
- Escape title and message before interpolation in getErrorPage()
- Add unit tests for XSS payloads, ampersands, and single quotes