### PR TITLE
fix(logger): redact secrets in debug output

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,6 +11,8 @@ export enum LogLevel {
   DEBUG = 4,
 }
 
+const REDACTION = '[REDACTED]';
+
 /**
  * Logger class for centralized logging with configurable log levels
  */
@@ -37,14 +39,19 @@ export class Logger {
   }
 
   /**
-   * Log a debug message (only shown at DEBUG level)
+   * Log a debug message (only shown at DEBUG level).
+   * Automatically redacts known secrets from string arguments.
    */
   public debug(message: string, ...arguments_: any[]): void {
     if (this.logLevel >= LogLevel.DEBUG) {
-      if (arguments_.length > 0) {
-        console.log(chalk.yellow(`DEBUG: ${message}`), ...arguments_);
+      const redactedMessage = redactSecrets(message);
+      const redactedArgs = arguments_.map((arg) =>
+        typeof arg === 'string' ? redactSecrets(arg) : arg,
+      );
+      if (redactedArgs.length > 0) {
+        console.log(chalk.yellow(`DEBUG: ${redactedMessage}`), ...redactedArgs);
       } else {
-        console.log(chalk.yellow(`DEBUG: ${message}`));
+        console.log(chalk.yellow(`DEBUG: ${redactedMessage}`));
       }
     }
   }
@@ -159,6 +166,29 @@ export class Logger {
       }
     }
   }
+}
+
+/**
+ * Redact known secret patterns from log strings.
+ * Handles Bearer tokens, URL query parameters (code, access_token,
+ * refresh_token), Berget API keys, and JWT-like strings.
+ */
+function redactSecrets(value: string): string {
+  let result = value;
+
+  // Bearer tokens
+  result = result.replace(/Bearer\s+\S+/gi, `Bearer ${REDACTION}`);
+
+  // URL query parameters: code=..., access_token=..., refresh_token=...
+  result = result.replace(/\b(code|access_token|refresh_token)=[^&\s]*/gi, `$1=${REDACTION}`);
+
+  // Berget API keys (sk_ber_*)
+  result = result.replace(/sk_ber_\w+/g, REDACTION);
+
+  // JWT-like strings (3 base64url segments separated by dots)
+  result = result.replace(/ey[A-Za-z0-9_-]*(?:\.[A-Za-z0-9_-]*){2,}/g, REDACTION);
+
+  return result;
 }
 
 // Export a singleton instance for easy import

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger, LogLevel } from '../../src/utils/logger.js';
+
+describe('Logger - secret redaction (debug)', () => {
+  let logger: Logger;
+  let stdout: string;
+
+  beforeEach(() => {
+    logger = new Logger();
+    logger.setLogLevel(LogLevel.DEBUG);
+    stdout = '';
+    vi.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+      stdout += args.join(' ') + '\n';
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('redacts Bearer tokens', () => {
+    logger.debug('Authorization: Bearer eyJhbGciOiJSUzI1NiIs...');
+    expect(stdout).not.toContain('eyJhbGciOiJSUzI1NiIs');
+    expect(stdout).toContain('Bearer [REDACTED]');
+  });
+
+  it('redacts access_token query parameter', () => {
+    logger.debug('URL: https://api.berget.ai/token?access_token=secret123&foo=bar');
+    expect(stdout).not.toContain('secret123');
+    expect(stdout).toContain('access_token=[REDACTED]');
+    expect(stdout).toContain('foo=bar');
+  });
+
+  it('redacts refresh_token query parameter', () => {
+    logger.debug('URL: https://api.berget.ai/token?refresh_token=abc123&foo=bar');
+    expect(stdout).not.toContain('abc123');
+    expect(stdout).toContain('refresh_token=[REDACTED]');
+    expect(stdout).toContain('foo=bar');
+  });
+
+  it('redacts authorization code', () => {
+    logger.debug('Callback URL: https://localhost/callback?code=authcode123&state=xyz');
+    expect(stdout).not.toContain('authcode123');
+    expect(stdout).toContain('code=[REDACTED]');
+    expect(stdout).toContain('state=xyz');
+  });
+
+  it('redacts sk_ber_* API keys', () => {
+    logger.debug('Using API key: sk_ber_live_abcdef123456');
+    expect(stdout).not.toContain('sk_ber_live_abcdef123456');
+    expect(stdout).toContain('[REDACTED]');
+  });
+
+  it('redacts JWT-like strings', () => {
+    logger.debug('Token: eyJhbGciOiJSUzI1NiIs.aW5mbyBzdHJpbmc.signature');
+    expect(stdout).not.toContain('eyJhbGciOiJSUzI1NiIs');
+    expect(stdout).toContain('[REDACTED]');
+  });
+
+  it('does not redact non-sensitive content', () => {
+    logger.debug('Hello world, this is safe');
+    expect(stdout).toContain('Hello world, this is safe');
+  });
+
+  it('does not break when there are no arguments', () => {
+    logger.debug('Simple message');
+    expect(stdout).toContain('Simple message');
+  });
+});


### PR DESCRIPTION
Fixes TODO.md issue #3.

**Problem:** logger.debug() emitted authorization URLs, tokens, and API keys without sanitization. Under LOG_LEVEL=debug these values end up in CI artifacts, shared terminals, or crash dumps.

**Changes:**
- Add redactSecrets() with regex patterns for Bearer, code=, access_token=, refresh_token=, sk_ber_* API keys, and JWT triplets
- Apply redaction to the message and all string arguments in debug()
- Add unit tests covering each pattern plus non-sensitive passthrough