### PR TITLE
refactor(code): remove deceptive coercion in configureAuth

### DIFF
--- a/src/commands/code/__tests__/auth-sync.test.ts
+++ b/src/commands/code/__tests__/auth-sync.test.ts
@@ -455,6 +455,34 @@ describe('configureAuth', () => {
     expect(result.authenticated).toBe(false);
   });
 
+  it('skips seat check when JWT cannot be decoded', async () => {
+    const files = new FakeFileStore();
+    // No prompts expected — the !jwtPayload guard should short-circuit
+    const prompter = new FakePrompter([]);
+
+    const deps = makeAuthDeps({ files, prompter });
+
+    const cliAuth: CliAuth = {
+      access_token: 'not-a-valid-jwt-string',
+      expires_at: Date.now() + 3600000,
+      refresh_token: 'ref',
+    };
+
+    const result = await configureAuth(deps, 'opencode', cliAuth);
+
+    expect(result.authenticated).toBe(true);
+    // No seat-selection prompt should have been shown
+    const selectCalls = prompter.calls.filter((c) => c.method === 'select');
+    expect(selectCalls).toHaveLength(0);
+    // OAuth was synced to the tool
+    expect(files.getWrittenFiles().has(HOME + '/.local/share/opencode/auth.json')).toBe(true);
+    // Warning note displayed
+    const notes = prompter.calls.filter((c) => c.method === 'note');
+    const warningNote = notes.find((n) => (n.args as any).title === 'Authentication');
+    expect(warningNote).toBeDefined();
+    expect((warningNote!.args as any).message).toContain('Could not verify');
+  });
+
   it('fails authentication when cliAuth is null', async () => {
     const prompter = new FakePrompter([]);
 

--- a/src/commands/code/auth-sync.ts
+++ b/src/commands/code/auth-sync.ts
@@ -72,7 +72,6 @@ export async function configureAuth(
 
   // Check Berget Code seat
   const jwtPayload = decodeJwtPayload(cliAuth.access_token);
-  const hasSeat = jwtPayload ? hasBergetCodeSeat(cliAuth.access_token) : true;
 
   // If we can't decode the JWT, sync OAuth anyway — the tokens are valid even if
   // we can't verify the subscription role. Let the tool handle authorization.
@@ -92,6 +91,9 @@ export async function configureAuth(
     );
     return { authenticated: true };
   }
+
+  // JWT decoded successfully — check subscription seat
+  const hasSeat = hasBergetCodeSeat(cliAuth.access_token);
 
   if (hasSeat) {
     // Case B: Has seat — ask how to authenticate


### PR DESCRIPTION
Fixes TODO.md issue #8.

**Problem:** When decodeJwtPayload() returned null, hasSeat was coerced to true, but the !jwtPayload guard intercepted it. This was a maintenance footgun.

**Changes:**
- Return early for !jwtPayload before computing hasSeat
- Add regression test asserting unparsable JWT skips seat prompt