### PR TITLE
fix(auth): retry transient network failures during token refresh

### DIFF
--- a/src/auth/__tests__/token-refresh.test.ts
+++ b/src/auth/__tests__/token-refresh.test.ts
@@ -7,6 +7,7 @@ import { refreshAccessToken } from '../oauth/token-refresh.js';
 let mockRefreshTokenGrantCalls: any[] = [];
 let mockRefreshTokenGrantResult: any = null;
 let mockRefreshTokenGrantError: Error | null = null;
+let mockRefreshTokenGrantSequence: Array<{ error?: Error; result?: any }> = [];
 
 vi.mock('openid-client', async () => {
   const ResponseBodyErrorClass = class extends Error {
@@ -25,6 +26,11 @@ vi.mock('openid-client', async () => {
   return {
     refreshTokenGrant: vi.fn(async (...args: any[]) => {
       mockRefreshTokenGrantCalls.push(args);
+      if (mockRefreshTokenGrantSequence.length > 0) {
+        const next = mockRefreshTokenGrantSequence.shift()!;
+        if (next.error) throw next.error;
+        return next.result;
+      }
       if (mockRefreshTokenGrantError) throw mockRefreshTokenGrantError;
       return mockRefreshTokenGrantResult;
     }),
@@ -37,6 +43,7 @@ describe('refreshAccessToken', () => {
     mockRefreshTokenGrantCalls = [];
     mockRefreshTokenGrantResult = null;
     mockRefreshTokenGrantError = null;
+    mockRefreshTokenGrantSequence = [];
   });
 
   const createMockStore = (
@@ -217,5 +224,66 @@ describe('refreshAccessToken', () => {
         refresh_token: 'refresh-token', // old one preserved
       }),
     );
+  });
+
+  it('retries on transient network failure and succeeds', async () => {
+    const store = createMockStore();
+    const mockConfig = createMockConfig();
+    const transientError = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    });
+
+    mockRefreshTokenGrantSequence = [
+      { error: transientError },
+      {
+        result: {
+          access_token: 'new-access',
+          expires_in: 3600,
+        },
+      },
+    ];
+
+    const result = await refreshAccessToken(mockConfig, store);
+
+    expect(result).toBe(true);
+    expect(mockRefreshTokenGrantCalls).toHaveLength(2);
+    expect(store.clear).not.toHaveBeenCalled();
+    expect(store.set).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: 'new-access' }),
+    );
+  });
+
+  it('retries up to 3 times on transient failures then gives up without clearing tokens', async () => {
+    const store = createMockStore();
+    const mockConfig = createMockConfig();
+
+    mockRefreshTokenGrantSequence = [
+      { error: Object.assign(new Error('ETIMEDOUT'), { code: 'ETIMEDOUT' }) },
+      { error: Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' }) },
+      { error: Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' }) },
+    ];
+
+    const result = await refreshAccessToken(mockConfig, store);
+
+    expect(result).toBe(false);
+    expect(mockRefreshTokenGrantCalls).toHaveLength(3);
+    expect(store.clear).not.toHaveBeenCalled();
+  });
+
+  it('does not retry on permanent auth errors', async () => {
+    const store = createMockStore();
+    const mockConfig = createMockConfig();
+
+    const { ResponseBodyError } = await import('openid-client');
+    mockRefreshTokenGrantError = new ResponseBodyError('invalid_grant', {
+      cause: { error: 'invalid_grant' },
+      response: new Response(null, { status: 400 }),
+    });
+
+    const result = await refreshAccessToken(mockConfig, store);
+
+    expect(result).toBe(false);
+    expect(mockRefreshTokenGrantCalls).toHaveLength(1); // No retry
+    expect(store.clear).toHaveBeenCalled();
   });
 });

--- a/src/auth/oauth/token-refresh.ts
+++ b/src/auth/oauth/token-refresh.ts
@@ -8,6 +8,27 @@ import type { TokenData } from '../types.js';
 
 import { extractJwtExpiresAt } from '../jwt.js';
 
+// Well-known transient network error codes. Retrying these is safe and
+// common, e.g. brief DNS failure, port temporarily unavailable.
+const TRANSIENT_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+]);
+
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 200;
+
+function isTransientError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code && TRANSIENT_ERROR_CODES.has(code)) return true;
+  return false;
+}
+
 // In-flight refresh promises keyed by config, then by store.
 // This prevents two calls with the SAME config+store from duplicating,
 // while ensuring different stores don't share promises.
@@ -36,47 +57,70 @@ export async function refreshAccessToken(
   return promise;
 }
 
+/**
+ * Try to refresh the access token with exponential backoff on transient
+ * network failures. Permanent auth errors clear stored tokens; transient
+ * errors are retried up to MAX_RETRIES and never delete tokens.
+ */
 async function doRefresh(config: Configuration, tokenStore: TokenStore): Promise<boolean> {
   const tokenData = await tokenStore.get();
   if (!tokenData?.refresh_token) return false;
 
-  try {
-    const result = await refreshTokenGrant(config, tokenData.refresh_token);
+  let attempt = 0;
 
-    // Extract tokens from response
-    const accessToken = result.access_token;
-    const refreshToken = result.refresh_token || tokenData.refresh_token;
-    const expiresIn = result.expires_in || 3600;
+  while (true) {
+    try {
+      const result = await refreshTokenGrant(config, tokenData.refresh_token);
 
-    // Calculate expiration from JWT or fallback
-    const jwtExpiresAt = extractJwtExpiresAt(accessToken);
-    const expiresAt = jwtExpiresAt > 0 ? jwtExpiresAt : Date.now() + expiresIn * 1000;
+      // Extract tokens from response
+      const accessToken = result.access_token;
+      const refreshToken = result.refresh_token || tokenData.refresh_token;
+      const expiresIn = result.expires_in || 3600;
 
-    const newTokenData: TokenData = {
-      access_token: accessToken,
-      expires_at: expiresAt,
-      refresh_token: refreshToken,
-    };
+      // Calculate expiration from JWT or fallback
+      const jwtExpiresAt = extractJwtExpiresAt(accessToken);
+      const expiresAt = jwtExpiresAt > 0 ? jwtExpiresAt : Date.now() + expiresIn * 1000;
 
-    await tokenStore.set(newTokenData);
-    return true;
-  } catch (error) {
-    // On invalid/expired refresh token (401/403 from Keycloak), clear tokens.
-    // ResponseBodyError from openid-client carries structured error info.
-    if (error instanceof ResponseBodyError) {
-      // Keycloak returns invalid_grant when the refresh token is expired or revoked
-      if (error.error === 'invalid_grant' || error.status === 401 || error.status === 403) {
-        await tokenStore.clear();
+      const newTokenData: TokenData = {
+        access_token: accessToken,
+        expires_at: expiresAt,
+        refresh_token: refreshToken,
+      };
+
+      await tokenStore.set(newTokenData);
+      return true;
+    } catch (error) {
+      // On invalid/expired refresh token (401/403 from Keycloak), clear tokens.
+      // ResponseBodyError from openid-client carries structured error info.
+      if (error instanceof ResponseBodyError) {
+        if (error.error === 'invalid_grant' || error.status === 401 || error.status === 403) {
+          await tokenStore.clear();
+        }
+        return false;
       }
-    } else if (
-      error instanceof Error &&
-      (error.message.includes('401') ||
-        error.message.includes('403') ||
-        error.message.includes('invalid_grant'))
-    ) {
-      // Fallback for non-standard error shapes (e.g. network-level failures)
-      await tokenStore.clear();
+
+      if (
+        error instanceof Error &&
+        (error.message.includes('401') ||
+          error.message.includes('403') ||
+          error.message.includes('invalid_grant'))
+      ) {
+        // Fallback for non-standard error shapes (e.g. network-level failures)
+        await tokenStore.clear();
+        return false;
+      }
+
+      if (isTransientError(error) && attempt < MAX_RETRIES - 1) {
+        await sleep(INITIAL_BACKOFF_MS * 2 ** attempt);
+        attempt++;
+        continue;
+      }
+
+      return false;
     }
-    return false;
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Fixes TODO.md issue #9.

**Problem:** Network failures during token refresh were treated as permanent, potentially causing premature token invalidation.

**Changes:**
- Add isTransientError() with a set of well-known transient error codes
- Wrap refreshTokenGrant in a retry loop (max 3 attempts) with exponential backoff starting at 200ms
- Transient errors are retried; permanent auth errors still clear tokens
- Add tests: retry succeeds, retry exhausted, no retry on permanent