### PR TITLE
fix(auth): improve error visibility in token store

### DIFF
--- a/src/auth/__tests__/storage/token-store.test.ts
+++ b/src/auth/__tests__/storage/token-store.test.ts
@@ -1,17 +1,28 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { logger } from '../../../utils/logger.js';
 import { FileTokenStore } from '../../storage/token-store.js';
 
 describe('FileTokenStore', () => {
   const getTempAuthPath = () => path.join(os.tmpdir(), `berget-auth-test-${Date.now()}.json`);
 
+  beforeEach(() => {
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns null when auth file does not exist', async () => {
     const store = new FileTokenStore(getTempAuthPath());
     const result = await store.get();
     expect(result).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('round-trips TokenData and preserves exact JSON shape', async () => {
@@ -78,13 +89,17 @@ describe('FileTokenStore', () => {
     ).toBe(false);
   });
 
-  it('returns null for malformed JSON', async () => {
+  it('returns null for malformed JSON and logs warning', async () => {
     const tempPath = getTempAuthPath();
     const store = new FileTokenStore(tempPath);
 
     await fs.writeFile(tempPath, 'not json');
     const result = await store.get();
     expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('corrupted'),
+      expect.any(String),
+    );
   });
 
   it('returns null for missing required fields', async () => {
@@ -94,5 +109,24 @@ describe('FileTokenStore', () => {
     await fs.writeFile(tempPath, JSON.stringify({ access_token: 'only' }));
     const result = await store.get();
     expect(result).toBeNull();
+  });
+
+  it('returns null and logs warning on permission error', async () => {
+    const tempPath = getTempAuthPath();
+    const store = new FileTokenStore(tempPath);
+
+    await fs.writeFile(tempPath, JSON.stringify({ access_token: 'tok', expires_at: 1, refresh_token: 'ref' }));
+    await fs.chmod(tempPath, 0o000);
+
+    const result = await store.get();
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('EACCES'),
+      expect.any(String),
+    );
+
+    // cleanup
+    await fs.chmod(tempPath, 0o600);
+    await fs.unlink(tempPath);
   });
 });

--- a/src/auth/storage/token-store.ts
+++ b/src/auth/storage/token-store.ts
@@ -4,6 +4,8 @@ import * as path from 'node:path';
 
 import type { TokenData } from '../types.js';
 
+import { logger } from '../../utils/logger.js';
+
 export interface TokenStore {
   clear(): Promise<void>;
   get(): Promise<null | TokenData>;
@@ -26,8 +28,22 @@ export class FileTokenStore implements TokenStore {
   }
 
   async get(): Promise<null | TokenData> {
+    let data: string | undefined;
     try {
-      const data = await fs.readFile(this.tokenFilePath, 'utf8');
+      data = await fs.readFile(this.tokenFilePath, 'utf8');
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        return null; // Not logged in — expected
+      }
+      logger.warn(
+        `Could not read auth file (${code || 'unknown error'}). Run \`berget auth login\` to re-authenticate.`,
+        String(error),
+      );
+      return null;
+    }
+
+    try {
       const parsed = JSON.parse(data) as TokenData;
       // Validate shape
       if (
@@ -38,7 +54,11 @@ export class FileTokenStore implements TokenStore {
         return parsed;
       }
       return null;
-    } catch {
+    } catch (error) {
+      logger.warn(
+        `Auth file appears corrupted. Run \`berget auth login\` to re-authenticate.`,
+        String(error),
+      );
       return null;
     }
   }

--- a/src/commands/code/auth-sync.ts
+++ b/src/commands/code/auth-sync.ts
@@ -8,6 +8,7 @@ import {
   hasBergetCodeSeat,
   isTokenExpired,
 } from '../../auth/jwt.js';
+import { logger } from '../../utils/logger.js';
 import { FatalError } from './errors.js';
 
 export interface AuthDeps {
@@ -234,25 +235,30 @@ export async function isToolAuthenticated(
 export async function readCliAuth(files: FileStore, homeDir: string): Promise<CliAuth | null> {
   const content = await files.readFile(CLI_AUTH_PATH(homeDir));
   if (!content) return null;
+  let parsed: any;
   try {
-    const parsed = JSON.parse(content);
-    if (parsed.access_token && parsed.refresh_token) {
-      // Extract the actual expiry time from the JWT token instead of using the stored expires_at
-      const jwtExpiresAt = extractJwtExpiresAt(parsed.access_token);
-      if (jwtExpiresAt === 0) {
-        // Invalid token, return null
-        return null;
-      }
-      return {
-        access_token: parsed.access_token,
-        expires_at: jwtExpiresAt,
-        refresh_token: parsed.refresh_token,
-      };
-    }
-    return null;
-  } catch {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    logger.warn(
+      `CLI auth file appears corrupted. Run \`berget auth login\` to re-authenticate.`,
+      String(error),
+    );
     return null;
   }
+  if (parsed.access_token && parsed.refresh_token) {
+    // Extract the actual expiry time from the JWT token instead of using the stored expires_at
+    const jwtExpiresAt = extractJwtExpiresAt(parsed.access_token);
+    if (jwtExpiresAt === 0) {
+      // Invalid token, return null
+      return null;
+    }
+    return {
+      access_token: parsed.access_token,
+      expires_at: jwtExpiresAt,
+      refresh_token: parsed.refresh_token,
+    };
+  }
+  return null;
 }
 
 export async function syncApiKeyToTool(


### PR DESCRIPTION
Fixes TODO.md issue #10.

**Problem:** FileTokenStore.get() and readCliAuth() swallowed all errors silently, returning null for everything. Permission errors or corruption were invisible.

**Changes:**
- Distinguish ENOENT (expected) from other fs/parse errors
- Log warnings for corrupted/unreadable auth files
- Add tests for corrupted JSON and permission errors