### PR TITLE
fix(auth): correct HTTP status codes and guard missing authorization code

### DIFF
--- a/src/auth/__tests__/pkce-flow.test.ts
+++ b/src/auth/__tests__/pkce-flow.test.ts
@@ -228,6 +228,7 @@ describe('startPkceFlow', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid state');
+    expect(res.writeHead).toHaveBeenCalledWith(403, expect.any(Object));
   });
 
   it('returns error when callback has error param', async () => {
@@ -252,6 +253,33 @@ describe('startPkceFlow', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('access_denied');
+    expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object));
+  });
+
+  it('returns error 400 when code is missing on valid state', async () => {
+    const mockServer = createMockServer();
+    const createServerFn = vi.fn(() => mockServer);
+    const mockConfig: any = {};
+
+    const flowPromise = startPkceFlow({
+      config: mockConfig,
+      createServer: createServerFn as any,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Valid state but no code (e.g., stray HTTP probe)
+    const req = {
+      url: '/callback?state=mock-state-uuid',
+    };
+    const res = { end: vi.fn(), writeHead: vi.fn() };
+    mockServer._triggerRequest(req, res);
+
+    const result = await flowPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Missing authorization code');
+    expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object));
   });
 
   it('passes the full callback URL to authorizationCodeGrant (regression: must preserve iss, session_state)', async () => {

--- a/src/auth/oauth/pkce-flow.ts
+++ b/src/auth/oauth/pkce-flow.ts
@@ -107,7 +107,7 @@ export async function startPkceFlow(options: PkceFlowOptions): Promise<BrowserAu
           if (debug) {
             logger.debug(`Callback returned OAuth error: ${error} — ${description}`);
           }
-          res.writeHead(200, { Connection: 'close', 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(400, { Connection: 'close', 'Content-Type': 'text/html; charset=utf-8' });
           res.end(getErrorPage('Authentication Failed', description));
           safeResolve({ error, success: false });
           return;
@@ -117,11 +117,18 @@ export async function startPkceFlow(options: PkceFlowOptions): Promise<BrowserAu
           if (debug) {
             logger.debug(`State mismatch: expected ${state}, got ${receivedState}`);
           }
-          res.writeHead(200, { Connection: 'close', 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(403, { Connection: 'close', 'Content-Type': 'text/html; charset=utf-8' });
           res.end(
             getErrorPage('Authentication Failed', 'Invalid state parameter. Please try again.'),
           );
           safeResolve({ error: 'Invalid state parameter', success: false });
+          return;
+        }
+
+        if (!code) {
+          res.writeHead(400, { Connection: 'close', 'Content-Type': 'text/html; charset=utf-8' });
+          res.end(getErrorPage('Authentication Failed', 'Missing authorization code.'));
+          safeResolve({ error: 'Missing authorization code', success: false });
           return;
         }
 


### PR DESCRIPTION
Combines fixes for TODO.md issues #11 and #12.

**Issue 11:** Missing  parameter fell through to success page.
**Issue 12:** Error callbacks returned HTTP 200.

**Changes:**
- Guard missing code → HTTP 400, error page
- OAuth error → HTTP 400 (was 200)
- State mismatch → HTTP 403 (was 200)
- Add regression tests