### PR TITLE
style: auto-fix ESLint/Prettier formatting in merged auth fixes

### DIFF
--- a/src/auth/__tests__/storage/token-store.test.ts
+++ b/src/auth/__tests__/storage/token-store.test.ts
@@ -115,15 +115,15 @@ describe('FileTokenStore', () => {
     const tempPath = getTempAuthPath();
     const store = new FileTokenStore(tempPath);
 
-    await fs.writeFile(tempPath, JSON.stringify({ access_token: 'tok', expires_at: 1, refresh_token: 'ref' }));
+    await fs.writeFile(
+      tempPath,
+      JSON.stringify({ access_token: 'tok', expires_at: 1, refresh_token: 'ref' }),
+    );
     await fs.chmod(tempPath, 0o000);
 
     const result = await store.get();
     expect(result).toBeNull();
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('EACCES'),
-      expect.any(String),
-    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('EACCES'), expect.any(String));
 
     // cleanup
     await fs.chmod(tempPath, 0o600);

--- a/src/auth/__tests__/token-refresh.test.ts
+++ b/src/auth/__tests__/token-refresh.test.ts
@@ -248,9 +248,7 @@ describe('refreshAccessToken', () => {
     expect(result).toBe(true);
     expect(mockRefreshTokenGrantCalls).toHaveLength(2);
     expect(store.clear).not.toHaveBeenCalled();
-    expect(store.set).toHaveBeenCalledWith(
-      expect.objectContaining({ access_token: 'new-access' }),
-    );
+    expect(store.set).toHaveBeenCalledWith(expect.objectContaining({ access_token: 'new-access' }));
   });
 
   it('retries up to 3 times on transient failures then gives up without clearing tokens', async () => {

--- a/src/auth/oauth/token-refresh.ts
+++ b/src/auth/oauth/token-refresh.ts
@@ -11,9 +11,9 @@ import { extractJwtExpiresAt } from '../jwt.js';
 // Well-known transient network error codes. Retrying these is safe and
 // common, e.g. brief DNS failure, port temporarily unavailable.
 const TRANSIENT_ERROR_CODES = new Set([
+  'EAI_AGAIN',
   'ECONNREFUSED',
   'ECONNRESET',
-  'EAI_AGAIN',
   'ENETUNREACH',
   'ENOTFOUND',
   'ETIMEDOUT',


### PR DESCRIPTION
This PR fixes formatting issues that caused CI failures on recently merged PRs.

Changes:
- Fix sort order in TRANSIENT_ERROR_CODES (perfectionist/sort-sets)
- Fix multi-line formatting in test assertions (prettier)