### PR TITLE
fix(auth): add offline_access scope for long-lived refresh tokens

### DIFF
--- a/src/auth/oauth/pkce-flow.ts
+++ b/src/auth/oauth/pkce-flow.ts
@@ -54,7 +54,7 @@ export async function startPkceFlow(options: PkceFlowOptions): Promise<BrowserAu
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       redirect_uri: redirectUri,
-      scope: 'openid email profile',
+      scope: 'openid email profile offline_access',
       state,
     });
 


### PR DESCRIPTION
CLI login was missing `offline_access` scope, causing refresh tokens to expire with the SSO session (~1h idle) instead of being long-lived offline tokens.

Users who onboarded via `berget code init` got short-lived refresh tokens and were logged out after roughly an hour of inactivity, while the opencode-auth plugin already requested `offline_access` and worked correctly.

This aligns the CLI PKCE scope with the plugin.

**Change**: `openid email profile` → `openid email profile offline_access` in `src/auth/oauth/pkce-flow.ts`